### PR TITLE
Fix irritating warning "The boot environment being modified is not the a...

### DIFF
--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -356,7 +356,7 @@ class BootEnv(object):
                                 # associated with other global zone BEs.)
                                 if be.get("active_unbootable", False):
                                         continue
-                                if be.get("active_boot"):
+                                if be.get("active_boot") and be.get("global_active", True):
                                         return be.get("orig_be_name")
                 except AttributeError:
                         raise api_errors.BENamingNotSupported(be_name)


### PR DESCRIPTION
...ctive one"

For correct work patch requires updated libbe_py. If global_active attribute is not exposed by libbe_py, the old behavior is preserved.
