### PR TITLE
pkglint_action.py : fix username regex

### DIFF
--- a/src/modules/lint/pkglint_action.py
+++ b/src/modules/lint/pkglint_action.py
@@ -1486,7 +1486,7 @@ class PkgActionChecker(base.ActionChecker):
                             pkg=manifest.fmri),
                             msgid="{0}{1}.2".format(self.name, pkglint_id))
 
-                if not re.match("^[a-z]([a-zA-Z1-9._-])*$", username):
+                if not re.match("^[a-z]([a-zA-Z0-9\._\-])*$", username):
                         engine.error(
                             _("Username {name} in {pkg} is invalid - see "
                             "passwd(4)").format(


### PR DESCRIPTION
Allow `0` in the name, and escape the period `\.` and minus `\-` to make sure they are matched verbatim (not as regex control chars)
