### PR TITLE
this method expects a solaris11 zone, where / is mounted usually from…

### DIFF
--- a/src/svc/svc-pkg-repositories-setup
+++ b/src/svc/svc-pkg-repositories-setup
@@ -47,13 +47,16 @@ case "$1" in
 			# /lib/svc/share/fs_include.sh
 			#
 			be=$special
-			rpool=$(print $be | cut -d / -f1)			
+			#rpool=$(print $be | cut -d / -f1)			
+			# we use now baseds, as OI does not provide a "fake" rpool for a zone
+			# we need to store our VARSHARE under <zoneroot>/ROOT/VARSHARE
+			baseds=$(/usr/bin/dirname $be)
 		else
 			# we're on a LiveCD, so exit immediately.
 			exit $SMF_EXIT_OK
 		fi
 
-		DS="$rpool/VARSHARE/pkg/repositories"
+		DS="$baseds/VARSHARE/pkg/repositories"
 
 		# If the dataset exists, we mount it along with any child
 		# datasets, then exit.
@@ -80,8 +83,8 @@ case "$1" in
 		$ZFS create -p $DS
 		check_failure $? "Unable to create $DS" $SMF_FMRI exit
 
-		for fs in "$rpool/VARSHARE/pkg" \
-		    "$rpool/VARSHARE/pkg/repositories" ; do
+		for fs in "$baseds/VARSHARE/pkg" \
+		    "$baseds/VARSHARE/pkg/repositories" ; do
 			$ZFS set canmount=noauto $fs
 		done
 


### PR DESCRIPTION
… rpool/ROOT/<be-name> and wants the VARSHARE (/var/share) to stay in rpool/VARSHARE.

In OpenIndiana, we don't "scope" the root-dataset to "rpool", we show the complete dataset name as it is in the global zone, so we can't just assume we can create a "VARSHARE" on $rpool.
therefore we look up the datasetname for the / fs, reduce it by the BE name and get something like
path/to/my/zones/<zonename>/ROOT
this will be our "baseds" variable value, where we will create all needed zfs.
