### PR TITLE
Remove dependency on GNU awk

### DIFF
--- a/src/brand/common.ksh
+++ b/src/brand/common.ksh
@@ -310,7 +310,7 @@ unconfigure_zone() {
 	ZONE_IS_MOUNTED=1
 	zoneadm -z $ZONENAME mount -f || fatal "$e_badmount"
 
-	ZONE_BRAND=`zoneadm list -pc | /usr/bin/gawk -v zone=$ZONENAME -F':' '$2 == zone { print $6 }'`
+	ZONE_BRAND=`zoneadm list -pc | /usr/bin/nawk -v zone=$ZONENAME -F':' '$2 == zone { print $6 }'`
 	if [[ $ZONE_BRAND = "ipkg" || $ZONE_BRAND = "nlipkg" ]]; then
 		zlogin -S $ZONENAME /usr/lib/brand/ipkg/system-unconfigure -R /a \
 		    >/dev/null 2>&1


### PR DESCRIPTION
The IPS brand code is dependent on GNU awk, which doesn't have to be always available. Use nawk.