### PR TITLE
Produce useful error message for imageplan failures

### DIFF
--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import print_function
@@ -2438,7 +2439,17 @@ class ImagePlan(object):
                                         if fmristr in skip_fmris:
                                                 continue
                                         act = pkg.actions.fromstr(actstr)
-                                        assert act.attrs[act.key_attr] == key
+                                        if act.attrs[act.key_attr] != key:
+                                                raise api_errors.InvalidPackageErrors([
+                                                    "{} has invalid manifest "
+                                                    "line:".format(
+                                                    fmristr),
+						    "    '{}'".format(actstr),
+                                                    "    '{}' != '{}'".format(
+                                                        act.attrs[act.key_attr],
+                                                        key
+                                                    )
+                                                    ])
                                         assert pns is None or \
                                             act.namespace_group == pns
                                         pns = act.namespace_group


### PR DESCRIPTION
https://illumos.org/issues/10169 is a case where a package which had a
trailing whitespace in its manifest 'license' line caused tracebacks
when installing unrelated packages.

This change causes error messages like this to be produced instead:

```
pkg install: The requested operation cannot be completed due to invalid package metadata.  Details follow:

pkg://openindiana.org/text/gnu-grep@3.3,5.11-2018.0.0.0:20181224T183734Z has invalid manifest line:
    'license 3e7ce9223a3d638f969ee023155c70c84b28b396 license="GPLv3, FDLv1.3 "'
    'GPLv3, FDLv1.3 ' != 'GPLv3, FDLv1.3'
```