### PR TITLE
A few more fixes from OmniOS

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -5982,6 +5982,9 @@ def handle_errors(func, non_wrap_print=True, *args, **kwargs):
                 error(_("Linked image exception(s):\n{0}").format(
                       str(__e)))
                 __ret = __e.lix_exitrv
+        except api_errors.PlanCreationException as __e:
+                error(__e)
+                __ret = EXIT_OOPS
         except api_errors.CertificateError as __e:
                 if _api_inst:
                         _api_inst.abort(result=RESULT_FAILED_CONFIGURATION)

--- a/src/client.py
+++ b/src/client.py
@@ -5857,7 +5857,7 @@ def main_func():
         # Get the available options for the requested operation to create the
         # getopt parsing strings.
         valid_opts = options.get_pkg_opts(subcommand, add_table=cmd_opts)
-        if not valid_opts:
+        if valid_opts is None:
                 # if there are no options for an op, it has its own processing
                 try:
                         return func(api_inst, pargs)

--- a/src/modules/actions/generic.py
+++ b/src/modules/actions/generic.py
@@ -1037,8 +1037,8 @@ class Action(object):
                             expected_id=group))
 
                 if mode is not None and stat.S_IMODE(lstat.st_mode) != mode:
-                        errors.append(_("Mode: {found:o} should be "
-                            "{expected:o}").format(
+                        errors.append(_("Mode: {found:04o} should be "
+                            "{expected:04o}").format(
                             found=stat.S_IMODE(lstat.st_mode),
                             expected=mode))
                 return lstat, errors, warnings, info, abort

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -3109,7 +3109,8 @@ class LinkedImageException(ApiException):
                             rv=rv, cmd=cmd)
                         if errout:
                                 err += _("\nAnd generated the following error "
-                                    "message:\n{errout}".format(errout=errout))
+                                    "message:\n{errout}".format(
+                                    errout=errout.decode()))
 
                 if cmd_output_invalid is not None:
                         (cmd, output) = cmd_output_invalid
@@ -3206,7 +3207,7 @@ return value of {exitrv:d} and generated the following output:
                                     lin=lin,
                                     op=op,
                                     exitrv=exitrv,
-                                    errout=errout,
+                                    errout=errout.decode(),
                                )
                         else:
                                 err = _("""
@@ -3221,7 +3222,7 @@ The child generated the following output:
                                 ).format(
                                     lin=lin,
                                     op=op,
-                                    errout=errout,
+                                    errout=errout.decode(),
                                     e=e,
                                )
 
@@ -3250,7 +3251,7 @@ The child generated the following output:
                                     lin=lin,
                                     op=op,
                                     e=e,
-                                    errout=errout,
+                                    errout=errout.decode(),
                                )
 
                 # set default error return value

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -130,21 +130,23 @@ def _get_pkg_output_schema(subcommand):
 
 def __get_pkg_input_schema(pkg_op, opts_mapping=misc.EmptyDict):
         properties = {}
-        for entry in options.pkg_op_opts[pkg_op]:
-                if type(entry) != tuple:
-                        continue
-                if len(entry) == 4:
-                        opt, dummy_default, dummy_valid_args, \
-                            schema = entry
+        opts = options.pkg_op_opts[pkg_op]
+        if opts is not None:
+                for entry in opts:
+                        if type(entry) != tuple:
+                                continue
+                        if len(entry) == 4:
+                                opt, dummy_default, dummy_valid_args, \
+                                    schema = entry
 
-                        if opt in opts_mapping:
-                                optn = opts_mapping[opt]
-                                if optn:
-                                        properties[optn] = schema
+                                if opt in opts_mapping:
+                                        optn = opts_mapping[opt]
+                                        if optn:
+                                                properties[optn] = schema
+                                        else:
+                                                properties[opt] = schema
                                 else:
                                         properties[opt] = schema
-                        else:
-                                properties[opt] = schema
 
         arg_name = "pargs_json"
         input_schema = \

--- a/src/modules/client/options.py
+++ b/src/modules/client/options.py
@@ -1336,7 +1336,7 @@ pkg_op_opts = {
     pkgdefs.PKG_OP_SET_PROP_LINKED: opts_set_property_linked,
     pkgdefs.PKG_OP_SYNC           : opts_sync_linked,
     pkgdefs.PKG_OP_UNINSTALL      : opts_uninstall,
-    pkgdefs.PKG_OP_UNSET_PUBLISHER: [],
+    pkgdefs.PKG_OP_UNSET_PUBLISHER: None,
     pkgdefs.PKG_OP_UPDATE         : opts_update,
     pkgdefs.PKG_OP_APPLY_HOT_FIX  : opts_apply_hot_fix,
     pkgdefs.PKG_OP_VERIFY         : opts_verify


### PR DESCRIPTION
### Adjust `pkg verify` output to zero-pad file modes:

```
bloody% pfexec chmod 1777 /root/.bashrc
bloody% pfexec pkg verify -p /root/.bashrc
PACKAGE                                                                 STATUS
pkg://omnios/SUNWcs                                                      ERROR
        file: root/.bashrc
                ERROR: Mode: 1777 should be 0644
```

### Fix `pkg pubcheck-linked`

```
bloody% pfexec pkg pubcheck-linked
Traceback (most recent call last):
  File "/usr/bin/pkg", line 5990, in handle_errors
    __ret = func(*args, **kwargs)
  File "/usr/bin/pkg", line 5892, in main_func
    return func(api_inst, pargs)
TypeError: pubcheck_linked() missing 1 required positional argument: 'pargs'
```

### Then fix the output of that, and other exceptions

From:
```
A 'pubcheck-linked' operation failed for child 'zone:test' with an unexpected
return value of 99 and generated the following output:
b'Traceback (most recent call last):\n  File "/usr/lib/python3.5/vendor-packages/jsonrpclib/SimpleJSONRPCServer.py", line 368, in _dispatch\n    func = self.funcs[method]\nKeyError: \'pubcheck-linked\'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/usr/bin/pkg", line 5990, in handle_errors\n    __ret = func(*args, **kwargs)\n  File "/usr/bin/pkg", line 1999, in __dispatch\n    rv = op_func(op, _api_inst, **pwargs)\n  File "/usr/bin/pkg", line 4576, in pubcheck_linked\n    api_inst.linked_publisher_check()\n  File "/usr/lib/python3.5/vendor-packages/pkg/client/api.py", line 215, in wrapper\n    return f(instance, *fargs, **f_kwargs)\n  File "/usr/lib/python3.5/vendor-packages/pkg/client/api.py", line 1706, in linked_publisher_check\n    self.__linked_pubcheck()\n  File "/usr/lib/python3.5/vendor-packages/pkg/client/api.py", line 1685, in __linked_pubcheck\n    self._img.linked.pubcheck()\n  File "/usr/lib/python3.5/vendor-packages/pkg/client/linkedimage/common.py", line 1080, in pubcheck\n    linked_pub_error=(pubs, ppubs))\npkg.client.api_errors.PlanCreationException: \nInvalid child image publisher configuration.  Child image publisher\nconfiguration must be a superset of the parent image publisher configuration.\nPlease update the child publisher configuration to match the parent.  If the\nchild image is a zone this can be done automatically by detaching and\nattaching the zone.\n\nThe parent image has the following enabled publishers:\n    PUBLISHER 0: on-nightly\n    PUBLISHER 1: omnios (non-sticky)\n\nThe child image has the following enabled publishers:\n    PUBLISHER 0: on-nightly\n    PUBLISHER 1: omnios\n\n\npkg: This is an internal error in pkg(5) version ab53fe4c8.  Please log a\nService Request about this issue including the information above and this\nmessage.\n'
```

To:
```
bloody# pkg pubcheck-linked
Linked image publisher check
pkg: Linked image exception(s):

A 'pubcheck-linked' operation failed for child 'zone:test' with an unexpected
return value of 1 and generated the following output:

pkg: Invalid child image publisher configuration.  Child image publisher
configuration must be a superset of the parent image publisher configuration.
Please update the child publisher configuration to match the parent.  If the
child image is a zone this can be done automatically by detaching and
attaching the zone.

The parent image has the following enabled publishers:
    PUBLISHER 0: omnios
    PUBLISHER 1: extra.omnios

The child image has the following enabled publishers:
    PUBLISHER 0: omnios (non-sticky)
    PUBLISHER 1: extra.omnios
```