### PR TITLE
hot-fix: support FTP for package retrieval

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -2335,7 +2335,8 @@ def apply_hot_fix(**args):
                 filepath = urlparse(origin, "file", allow_fragments=0)[2]
                 shutil.copy2(unquote(filepath), tmp_pth)
                 origin = misc.parse_uri(tmp_pth, cwd=orig_cwd)
-        elif origin.startswith("http://") or origin.startswith("https://"):
+        elif origin.startswith("http://") or origin.startswith("https://") or \
+            origin.startswith("ftp://"):
                 # Download file to temporary area
 
                 if not args['quiet']:


### PR DESCRIPTION
Since `apply-hot-fix` uses curl for file retrieval, FTP URI works.

Test suite run (likely unrelated to my change):
```
======================================================================
FAIL: cli.t_pkg_sysrepo.py TestSysrepo.test_disabled_origins
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./pkg5unittest.py", line 763, in run
    testMethod()
  File "./api/../cli/t_pkg_sysrepo.py", line 2282, in test_disabled_origins
    self.assertTrue("localhost:12007" in self.output)
AssertionError: False is not true

======================================================================
FAIL: cli.t_pkg_linked.py TestPkgLinkedRecurse.test_recursive_idr_removal
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./pkg5unittest.py", line 763, in run
    testMethod()
  File "./api/../cli/t_pkg_linked.py", line 2576, in test_recursive_idr_removal
    self._pkg([0, 1, 2], "install -v no-idrs")
  File "./api/../cli/t_pkg_linked.py", line 302, in _pkg
    exit=rv, env_arg=env_arg)
  File "./pkg5unittest.py", line 2574, in pkg
    env_arg=env_arg, coverage=coverage, handle=handle)
  File "./pkg5unittest.py", line 521, in cmdline_run
    comment)
pkg5unittest.UnexpectedExitCodeException: 
  Invoked:   /usr/bin/python3.5 /tmp/ips.test.14369/fakeroot/pkg -D plandesc_validate=1 -D manifest_validate=Always -D smf_cmds_dir=/tmp/ips.test.14369/2/smf_cmds -R /tmp/ips.test.14369/2/image0 install -v no-idrs 
  Expected exit status: [0].  Got: 1.  Output Follows:
,---------------------------------------------------------------------
| $   /usr/bin/python3.5 /tmp/ips.test.14369/fakeroot/pkg -D plandesc_validate=1 -D manifest_validate=Always -D smf_cmds_dir=/tmp/ips.test.14369/2/smf_cmds -R /tmp/ips.test.14369/2/image0 install -v no-idrs 
|  Startup: Linked image publisher check ... Done
|  Startup: Refreshing catalog 'test' ... Done
| Planning: Solver setup ... Done (0.002s)
| Planning: Running solver ... Done (0.001s)
| Planning: Finding local manifests ... Done (0.000s)
| Planning: Fetching manifests: 0/1  0% complete
| Planning: Fetching manifests: 1/1  100% complete
| Planning: Package planning ... Done (0.009s)
| Planning: Merging actions ... Done (0.001s)
| Planning: Checking for conflicting actions ... Done (0.003s)
| Planning: Consolidating action changes ... Done (0.001s)
| Planning: Evaluating mediators ... Done (0.002s)
| Planning: Planning completed in 0.03 seconds
|            Packages to install:        1
|      Estimated space available:  5.03 GB
| Estimated space to be consumed: 34.79 kB
|           Rebuild boot archive:       No
| 
| Changed packages:
| test
|   no-idrs
|     None -> 1.0-0
| 
| Planning: Linked images: 0/2 done; 1 working: system:img1
| Planning: Linked image 'system:img1' output:
| |      Estimated space available:  5.01 GB
| | Estimated space to be consumed: 34.32 kB
| |           Rebuild boot archive:       No
| |
| `
| Planning: Linked images: 1/2 done; 1 working: system:img2
| Planning: Linked image 'system:img2' output:
| |      Estimated space available:  5.01 GB
| | Estimated space to be consumed: 34.32 kB
| |           Rebuild boot archive:       No
| |
| `
| Planning: Finished processing linked images.
| Download: Linked images: 0/2 done; 1 working: system:img1
| Download: Linked images: 1/2 done; 1 working: system:img2
| Download: Finished processing linked images.
|  Actions: 1/2 actions (Installing new actions)
|  Actions: Completed 2 actions in 0.00 seconds.
|  Done (0.001s)
|  Done (0.000s)
|  Done (0.004s)
|  Done (0.001s)
|  Done (0.000s)
|  Done (0.000s)
| Finalize: Linked images: 0/2 done; 1 working: system:img1
| Finalize: Linked images: 1/2 done; 1 working: system:img2
| pkg: install failed (linked image exception(s)):
| 
| A 'sync-linked' operation failed for child 'system:img2' with an unexpected
| exception:
| <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
| 
| 
| The child generated the following output:
| localhost - - [20/Dec/2019 14:33:52] code 400, message Bad request syntax ('{"jsonrpc": "2.0", "id": "49f086bb-48ee-457f-8be0-abad8afaafbf", "method": "sync-linked", "params": {"li_ignore": null, "li_md_only": false, "verbose": 1, "backup_be_name": null, "origins": [], "reject_pats": [], "refresh_catalogs": true, "accept": true, "li_target_all": false, "show_licenses": false, "stage": "execute", "be_name": null, "parsable_version": null, "noexecute": false, "quiet": false, "li_target_list": [], "be_activate": true, "backup_be": null, "li_parent_sync": true, "new_be": null, "li_pkg_updates": true, "update_index": true}}')
| 
| 
| 
| 
`---------------------------------------------------------------------


# ----------------------------------------------------------------------

# Ran 1132 tests in 1691.924s - skipped 1 tests.

FAILED (successes=1130, failures=2, errors=0, mismatches=3)

======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
cli.t_pkgrepo.py TestPkgRepo.test_10_list: pass
cli.t_pkg_sysrepo.py TestSysrepo.test_disabled_origins: fail
cli.t_pkg_linked.py TestPkgLinkedRecurse.test_recursive_idr_removal: fail
======================================================================
```

@citrus-it FYI.