### PR TITLE
Replace simplejson with rapidjson

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -22,7 +22,7 @@
 
 #
 # Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -67,7 +67,6 @@ try:
         import getopt
         import gettext
         import itertools
-        import simplejson as json
         import locale
         import logging
         import os
@@ -96,6 +95,7 @@ try:
         import pkg.client.transport.transport as transport
         import pkg.client.options as options
         import pkg.fmri as fmri
+        import pkg.json as json
         import pkg.misc as misc
         import pkg.pipeutils as pipeutils
         import pkg.portable as portable

--- a/src/depot-config.py
+++ b/src/depot-config.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import pkg.no_site_packages
@@ -34,7 +35,6 @@ import os
 import re
 import shutil
 import six
-import simplejson as json
 import socket
 import sys
 import traceback
@@ -48,6 +48,7 @@ import pkg
 import pkg.client.api_errors as apx
 import pkg.catalog
 import pkg.config as cfg
+import pkg.json as json
 import pkg.misc as misc
 import pkg.portable as portable
 import pkg.p5i as p5i

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -22,7 +22,7 @@
 
 #
 # Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 """This module provides the supported, documented interface for clients to
@@ -63,7 +63,6 @@ import fnmatch
 import glob
 import os
 import shutil
-import simplejson as json
 import sys
 import tempfile
 import threading
@@ -90,6 +89,7 @@ import pkg.client.plandesc as plandesc
 import pkg.client.publisher as publisher
 import pkg.client.query_parser as query_p
 import pkg.fmri as fmri
+import pkg.json as json
 import pkg.mediator as med
 import pkg.misc as misc
 import pkg.nrlock
@@ -1599,7 +1599,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
                         pd_json1 = self.__plan_desc.getstate(self.__plan_desc,
                             reset_volatiles=True)
                         fobj = tempfile.TemporaryFile(mode="w+")
-                        json.dump(pd_json1, fobj, encoding="utf-8")
+                        json.dump(pd_json1, fobj)
                         pd_new = plandesc.PlanDescription(_op)
                         pd_new._load(fobj)
                         pd_json2 = pd_new.getstate(pd_new, reset_volatiles=True)

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 
@@ -31,7 +32,6 @@ import datetime
 import errno
 import getopt
 import itertools
-import simplejson as json
 import os
 import re
 import six
@@ -41,7 +41,6 @@ import tempfile
 import textwrap
 import time
 import traceback
-import jsonschema
 
 from six.moves import filter, map, range
 
@@ -55,6 +54,7 @@ import pkg.client.linkedimage as li
 import pkg.client.publisher as publisher
 import pkg.client.options as options
 import pkg.fmri as fmri
+import pkg.json as json
 import pkg.misc as misc
 import pkg.pipeutils as pipeutils
 import pkg.portable as portable
@@ -540,8 +540,8 @@ def __prepare_json(status, op=None, schema=None, data=None, errors=None):
         if op:
                 op_schema = _get_pkg_output_schema(op)
                 try:
-                        jsonschema.validate(ret_json, op_schema)
-                except jsonschema.ValidationError as e:
+                        json.validate(ret_json, op_schema)
+                except json.ValidationError as e:
                         newret_json = {"status": EXIT_OOPS,
                             "errors": [{"reason": str(e)}]}
                         return newret_json
@@ -2898,9 +2898,9 @@ def __pkg(subcommand, pargs_json, opts_json, pkg_image=None,
                 # Validate JSON input with JSON schema.
                 input_schema = _get_pkg_input_schema(subcommand,
                     opts_mapping=opts_mapping)
-                jsonschema.validate({arg_name: pargs, "opts_json": opts},
+                json.validate({arg_name: pargs, "opts_json": opts},
                     input_schema)
-        except jsonschema.ValidationError as e:
+        except json.ValidationError as e:
                 return None, __prepare_json(EXIT_BADOPT,
                     errors=[{"reason": str(e)}])
 

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -22,7 +22,7 @@
 
 #
 # Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import atexit
@@ -35,7 +35,6 @@ import hashlib
 import os
 import platform
 import shutil
-import simplejson as json
 import six
 import stat
 import sys
@@ -65,6 +64,7 @@ import pkg.client.transport.transport   as transport
 import pkg.config                       as cfg
 import pkg.file_layout.layout           as fl
 import pkg.fmri
+import pkg.json                         as json
 import pkg.lockfile                     as lockfile
 import pkg.manifest                     as manifest
 import pkg.mediator                     as med
@@ -4805,7 +4805,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
 
                 return img.imageplan.nothingtodo()
 
-        # avoid set implementation uses simplejson to store a set of pkg_stems
+        # avoid set implementation uses json to store a set of pkg_stems
         # being avoided (explicitly or implicitly), and a set of tracked stems
         # that are obsolete.
         #
@@ -4904,7 +4904,7 @@ in the environment or by setting simulate_cmdpath in DebugValues.""")
 
                 self.__avoid_set_altered = False
 
-        # frozen dict implementation uses simplejson to store a dictionary of
+        # frozen dict implementation uses json to store a dictionary of
         # pkg_stems that are frozen, the versions at which they're frozen, and
         # the reason, if given, why the package was frozen.
         #

--- a/src/modules/client/plandesc.py
+++ b/src/modules/client/plandesc.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 """
@@ -40,7 +41,6 @@ modified within an image during an image-modifying operation.
 import collections
 import itertools
 import operator
-import simplejson as json
 import six
 
 import pkg.actions
@@ -50,6 +50,7 @@ import pkg.client.linkedimage as li
 import pkg.client.pkgplan
 import pkg.facet
 import pkg.fmri
+import pkg.json as json
 import pkg.misc
 import pkg.version
 
@@ -326,7 +327,7 @@ class PlanDescription(object):
                     reset_volatiles=reset_volatiles)
                 try:
                         fobj.truncate()
-                        json.dump(state, fobj, encoding="utf-8")
+                        json.dump(state, fobj)
                         fobj.flush()
                 except OSError as e:
                         # Access to protected member; pylint: disable=W0212
@@ -342,8 +343,7 @@ class PlanDescription(object):
 
                 try:
                         fobj.seek(0)
-                        state = json.load(fobj, encoding="utf-8",
-                            object_hook=pkg.misc.json_hook)
+                        state = json.load(fobj, object_hook=pkg.misc.json_hook)
                 except OSError as e:
                         # Access to protected member; pylint: disable=W0212
                         raise apx._convert_error(e)

--- a/src/modules/client/progress.py
+++ b/src/modules/client/progress.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 #
@@ -35,7 +36,6 @@ import inspect
 import itertools
 import math
 import sys
-import simplejson as json
 import time
 from collections import deque
 from functools import wraps
@@ -48,6 +48,7 @@ import six
 import pkg.client.pkgdefs as pkgdefs
 import pkg.client.publisher as publisher
 import pkg.fmri
+import pkg.json as json
 import pkg.misc as misc
 
 from pkg.client import global_settings

--- a/src/modules/client/rad_pkg.py
+++ b/src/modules/client/rad_pkg.py
@@ -22,11 +22,11 @@
 
 #
 # Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import os
 import six
-import simplejson as json
 import subprocess
 import traceback
 import pkg
@@ -34,6 +34,7 @@ import pkg.fmri as fmri
 import pkg.client.client_api as entry
 import pkg.client.pkgdefs as pkgdefs
 import pkg.client.progress as progress
+import pkg.json as json
 
 # progress delay.
 PROG_DELAY   = 5.0

--- a/src/modules/client/transport/repo.py
+++ b/src/modules/client/transport/repo.py
@@ -22,13 +22,13 @@
 
 #
 # Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import errno
 import itertools
 import os
 import shutil
-import simplejson as json
 import six
 import sys
 import tempfile
@@ -45,6 +45,7 @@ import pkg.client.api_errors as apx
 import pkg.client.publisher as pub
 import pkg.client.transport.exception as tx
 import pkg.config as cfg
+import pkg.json as json
 import pkg.p5p
 import pkg.server.repository as svr_repo
 import pkg.server.query_parser as sqp

--- a/src/modules/client/transport/transport.py
+++ b/src/modules/client/transport/transport.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import  print_function
@@ -29,7 +30,6 @@ import copy
 import datetime as dt
 import errno
 import os
-import simplejson as json
 import six
 import tempfile
 import zlib
@@ -55,6 +55,7 @@ import pkg.client.progress as progress
 import pkg.digest as digest
 import pkg.file_layout.file_manager as fm
 import pkg.fmri
+import pkg.json as json
 import pkg.manifest as manifest
 import pkg.misc as misc
 import pkg.nrlock as nrlock

--- a/src/modules/json.py
+++ b/src/modules/json.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3.5
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
+
+"""
+json module abstraction for the packaging system.
+"""
+
+############################################################################
+# Standard version
+
+from rapidjson import loads, load, dumps, dump, JSONDecodeError
+from jsonschema import validate, ValidationError
+
+############################################################################
+# Debug/profiling version
+
+##from pkg.client.debugvalues import DebugValues
+##import pkg.misc as misc
+##
+##import os, time
+##import rapidjson as _json
+##
+##JSONDecodeError = _json.JSONDecodeError
+##
+##def _start():
+##    global rss, start
+##    psinfo = misc.ProcFS.psinfo()
+##    rss = psinfo.pr_rssize
+##    start = time.time()
+##
+##def _end(func, param, ret):
+##    taken = time.time() - start
+##    psinfo = misc.ProcFS.psinfo()
+##    mem = (psinfo.pr_rssize - rss) / 1024.0
+##    print("JSON Mem +{:.2f} MiB - Time {:.2f}s - {}({}) = {}"
+##        .format(mem, taken, func, param, ret))
+##
+##def _file(stream):
+##        try:
+##            name = stream.name
+##            size = os.path.getsize(name) / (1024.0 * 1024.0)
+##            return "{:.2f} MiB {}".format(size, name)
+##        except:
+##            return str(stream)
+##
+##def load(stream, **kw):
+##    if "json" in DebugValues:
+##        _start()
+##        ret = _json.load(stream, **kw)
+##        _end('load', _file(stream), '')
+##        return ret
+##    else:
+##        return _json.load(stream, **kw)
+##
+##def loads(str, **kw):
+##    if "json" in DebugValues:
+##        _start()
+##        ret = _json.loads(str, **kw)
+##        _end('loads', len(str), '')
+##        return ret
+##    else:
+##        return _json.loads(str, **kw)
+##
+##def dump(obj, stream, **kw):
+##    if "json" in DebugValues:
+##        _start()
+##        ret = _json.dump(obj, stream, **kw)
+##        _end('dump', _file(stream), ret)
+##        return ret
+##    else:
+##        return _json.dump(obj, stream, **kw)
+##
+##def dumps(obj, **kw):
+##    if "json" in DebugValues:
+##        _start()
+##        ret = _json.dumps(obj, **kw)
+##        _end('dumps', '', len(ret))
+##        return ret
+##    else:
+##        return _json.dumps(obj, **kw)
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -22,6 +22,7 @@
 
 # Copyright (c) 2007, 2017, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2014, OmniTI Computer Consulting, Inc. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 """
 Misc utility functions used by the packaging system.
@@ -44,7 +45,6 @@ import re
 import resource
 import shutil
 import signal
-import simplejson as json
 import socket
 import struct
 import sys
@@ -73,6 +73,7 @@ from six.moves.urllib.request import pathname2url, url2pathname
 import six
 
 import pkg.client.api_errors as api_errors
+import pkg.json as json
 import pkg.portable as portable
 import pkg.digest as digest
 

--- a/src/modules/p5i.py
+++ b/src/modules/p5i.py
@@ -22,10 +22,10 @@
 
 #
 # Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import os
-import simplejson as json
 
 from six.moves.urllib.error import HTTPError
 from six.moves.urllib.parse import urlunparse
@@ -33,6 +33,7 @@ from six.moves.urllib.request import urlopen, pathname2url
 
 import pkg.client.api_errors as api_errors
 import pkg.client.publisher as publisher
+import pkg.json as json
 import pkg.fmri as fmri
 
 CURRENT_VERSION = 1

--- a/src/modules/p5s.py
+++ b/src/modules/p5s.py
@@ -22,15 +22,16 @@
 
 #
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import copy
 import os
-import simplejson as json
 from six.moves.urllib.parse import urlparse, urlunparse
 
 import pkg.client.api_errors as api_errors
 import pkg.client.publisher as publisher
+import pkg.json as json
 import pkg.digest as digest
 import pkg.fmri as fmri
 from pkg.client.imageconfig import DEF_TOKEN

--- a/src/modules/server/depot.py
+++ b/src/modules/server/depot.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import division
@@ -51,7 +52,6 @@ import random
 import re
 import shutil
 import six
-import simplejson as json
 import socket
 import tarfile
 import tempfile
@@ -73,6 +73,7 @@ import pkg
 import pkg.actions as actions
 import pkg.config as cfg
 import pkg.fmri as fmri
+import pkg.json as json
 import pkg.indexer as indexer
 import pkg.manifest as manifest
 import pkg.misc as misc

--- a/src/modules/server/repository.py
+++ b/src/modules/server/repository.py
@@ -20,6 +20,7 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from __future__ import print_function
 
@@ -1995,8 +1996,8 @@ class _RepoStore(object):
                                         with codecs.EncodedFile(f, "utf-8") as ef:
                                                 p5i.write(ef, [pub])
                         else:
-                               # we use simpleson.dump() in p5i.write(),
-                               # simplejson module will produce str objects
+                               # we use json.dump() in p5i.write(),
+                               # json module will produce str objects
                                # in Python 3, therefore fp.write()
                                # must support str input.
 

--- a/src/pkg/external_deps.txt
+++ b/src/pkg/external_deps.txt
@@ -12,7 +12,7 @@
     pkg:/library/python/pybonjour-35
     pkg:/library/python/pycurl-35
     pkg:/library/python/pyopenssl-35
-    pkg:/library/python/simplejson-35
+    pkg:/library/python/rapidjson-35
     pkg:/library/python/six-35
     pkg:/package/svr4
     pkg:/runtime/python-35

--- a/src/pkg/manifests/developer:opensolaris:pkg5.p5m
+++ b/src/pkg/manifests/developer:opensolaris:pkg5.p5m
@@ -47,7 +47,7 @@ depend type=require fmri=pkg:/library/python/prettytable-35
 depend type=require fmri=pkg:/library/python/pybonjour-35
 depend type=require fmri=pkg:/library/python/pycurl-35
 depend type=require fmri=pkg:/library/python/pyopenssl-35
-depend type=require fmri=pkg:/library/python/simplejson-35
+depend type=require fmri=pkg:/library/python/rapidjson-35
 depend type=require fmri=pkg:/library/python/six-35
 depend type=require fmri=pkg:/package/svr4
 depend type=require fmri=pkg:/runtime/python-35

--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -20,7 +20,7 @@
 #
 # Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
 # Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 <transform file path=usr/bin/ -> set pkg.depend.bypass-generate .*six.*>
@@ -163,6 +163,7 @@ file path=$(PYDIRVP)/pkg/flavor/smf_manifest.py \
     pkg.depend.bypass-generate=.*six.*
 file path=$(PYDIRVP)/pkg/fmri.py pkg.depend.bypass-generate=.*six.*
 file path=$(PYDIRVP)/pkg/indexer.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/json.py pkg.depend.bypass-generate=.*six.*
 dir  path=$(PYDIRVP)/pkg/lint
 file path=$(PYDIRVP)/pkg/lint/__init__.py
 file path=$(PYDIRVP)/pkg/lint/base.py pkg.depend.bypass-generate=.*six.*
@@ -497,6 +498,6 @@ depend type=require fmri=library/python/prettytable-35
 depend type=require fmri=library/python/pybonjour-35
 depend type=require fmri=library/python/pycurl-35
 depend type=require fmri=library/python/pyopenssl-35
-depend type=require fmri=library/python/simplejson-35@3.6.5
+depend type=require fmri=library/python/rapidjson-35
 depend type=require fmri=library/python/six-35
 depend type=require fmri=locale/en

--- a/src/pkgrepo.py
+++ b/src/pkgrepo.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 import pkg.no_site_packages
 
@@ -79,9 +80,9 @@ import pkg.client.progress
 import pkg.client.publisher as publisher
 import pkg.client.transport.transport as transport
 import pkg.fmri as fmri
+import pkg.json as json
 import pkg.misc as misc
 import pkg.server.repository as sr
-import simplejson as json
 
 logger = global_settings.logger
 

--- a/src/rad-invoke.py
+++ b/src/rad-invoke.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import pkg.no_site_packages
@@ -33,9 +34,8 @@ import logging
 import os
 import pkg
 import pkg.client.rad_pkg as entry
+import pkg.json as json
 import pkg.misc as misc
-import simplejson as json
-
 
 class _InfoFilter(logging.Filter):
         def filter(self, rec):

--- a/src/sysrepo.py
+++ b/src/sysrepo.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 import pkg.no_site_packages
@@ -33,7 +34,6 @@ import locale
 import logging
 import os
 import shutil
-import simplejson
 import six
 import socket
 import stat
@@ -55,6 +55,7 @@ import pkg.client.api
 import pkg.client.progress as progress
 import pkg.client.api_errors as apx
 import pkg.digest as digest
+import pkg.json as json
 import pkg.misc as misc
 import pkg.portable as portable
 import pkg.p5p as p5p
@@ -341,8 +342,8 @@ def _load_publisher_info(api_inst, image_dir):
 
                 with open(cache_path, "r") as cache_file:
                         try:
-                                pub_info_tuple = simplejson.load(cache_file)
-                        except simplejson.JSONDecodeError:
+                                pub_info_tuple = json.load(cache_file)
+                        except json.JSONDecodeError:
                                 error(_("Invalid config cache file at {0} "
                                     "generating fresh configuration.").format(
                                     cache_path))
@@ -396,8 +397,8 @@ def _store_publisher_info(uri_pub_map, no_uri_pubs, image_dir):
                         pass
 
                 with open(cache_path, "w") as cache_file:
-                        simplejson.dump((uri_pub_map, no_uri_pubs), cache_file,
-                            indent=True)
+                        json.dump((uri_pub_map, no_uri_pubs), cache_file,
+                            indent=4)
                         os.chmod(cache_path, 0o600)
         except IOError as e:
                 error(_("Unable to store config to {cache_path}: {e}").format(

--- a/src/tests/api/t_api.py
+++ b/src/tests/api/t_api.py
@@ -116,8 +116,6 @@ class TestPkgApi(pkg5unittest.SingleDepotTestCase):
             add license license.licensed license=license.licensed must-accept=True
             close """
 
-        # NOTE:  spaces at the end (or lack thereof) here are important for
-        # specific versions of simplejson.
         p5i_bobcat = """{
   "packages": [
     "pkg:/bar@1.0,5.11-0", 

--- a/src/tests/api/t_catalog.py
+++ b/src/tests/api/t_catalog.py
@@ -22,6 +22,7 @@
 #
 
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from __future__ import print_function
 from . import testutils
@@ -32,7 +33,6 @@ import pkg5unittest
 import errno
 import os
 import shutil
-import simplejson
 import six
 import stat
 import unittest
@@ -40,6 +40,7 @@ from functools import cmp_to_key
 
 import pkg.actions
 import pkg.fmri as fmri
+import pkg.json as json
 import pkg.catalog as catalog
 import pkg.client.api_errors as api_errors
 import pkg.manifest as manifest
@@ -1191,11 +1192,11 @@ class TestCorruptCatalog(pkg5unittest.Pkg5TestCase):
                 # corrupt it
                 fname = os.path.join(self.test_root, "catalog.attrs")
                 f = open(fname, "r")
-                struct = simplejson.load(f)
+                struct = json.load(f)
                 f.close()
                 del struct["parts"]
                 f = open(fname, "w")
-                print(simplejson.dumps(struct), file=f)
+                print(json.dumps(struct), file=f)
                 f.close()
 
                 self.assertRaises(api_errors.InvalidCatalogFile,
@@ -1211,13 +1212,13 @@ class TestCorruptCatalog(pkg5unittest.Pkg5TestCase):
                 # corrupt it
                 fname = os.path.join(self.test_root, "catalog.attrs")
                 f = open(fname, "r")
-                struct = simplejson.load(f)
+                struct = json.load(f)
                 f.close()
                 # corrupt signature by one digit
                 sig = int(struct["_SIGNATURE"]["sha-1"], 16)
                 struct["_SIGNATURE"]["sha-1"] = "{0:x}".format(sig + 1)
                 f = open(fname, "w")
-                print(simplejson.dumps(struct), file=f)
+                print(json.dumps(struct), file=f)
                 f.close()
 
                 c = catalog.Catalog(meta_root=self.test_root)
@@ -1236,11 +1237,11 @@ class TestCorruptCatalog(pkg5unittest.Pkg5TestCase):
                 # corrupt it by removing _SIGNATURE
                 fname = os.path.join(self.test_root, "catalog.attrs")
                 f = open(fname, "r")
-                struct = simplejson.load(f)
+                struct = json.load(f)
                 f.close()
                 del struct["_SIGNATURE"]
                 f = open(fname, "w")
-                print(simplejson.dumps(struct), file=f)
+                print(json.dumps(struct), file=f)
                 f.close()
 
                 c = catalog.Catalog(meta_root=self.test_root)
@@ -1259,11 +1260,11 @@ class TestCorruptCatalog(pkg5unittest.Pkg5TestCase):
                 # corrupt it by adding a bad name to the set of parts.
                 fname = os.path.join(self.test_root, "catalog.attrs")
                 f = open(fname, "r")
-                struct = simplejson.load(f)
+                struct = json.load(f)
                 f.close()
                 struct["parts"]["/badpartname/"] = {}
                 f = open(fname, "w")
-                print(simplejson.dumps(struct), file=f)
+                print(json.dumps(struct), file=f)
                 f.close()
 
                 # Catalog constructor should reject busted 'parts'

--- a/src/tests/api/t_p5i.py
+++ b/src/tests/api/t_p5i.py
@@ -50,7 +50,7 @@ class TestP5I(pkg5unittest.Pkg5TestCase):
 
         #
         # Whitespace (or lack thereof) at the ends of some lines in the below is
-        # significant. It's also a function of which simplejson version you're
+        # significant. It's also a function of which json version you're
         # running/using.
         #
         p5i_bobcat = """{

--- a/src/tests/cli/t_client_api.py
+++ b/src/tests/cli/t_client_api.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from . import testutils
@@ -32,8 +33,7 @@ import pkg5unittest
 import os
 import pkg.client.client_api as cli_api
 import pkg.client.progress as progress
-import simplejson as json
-import jsonschema
+import pkg.json as json
 
 from pkg.client import global_settings
 
@@ -209,7 +209,7 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
                 """Test if the input is valid against the schema."""
 
                 try:
-                        jsonschema.validate(input, schema)
+                        json.validate(input, schema)
                         return True
                 except Exception as e:
                         return False

--- a/src/tests/cli/t_fix.py
+++ b/src/tests/cli/t_fix.py
@@ -21,6 +21,7 @@
 #
 
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
 if __name__ == "__main__":
@@ -33,11 +34,11 @@ import pkg.manifest as manifest
 import pkg.portable as portable
 import pkg.misc as misc
 import shutil
-import simplejson as json
 import tempfile
 import time
 import unittest
 
+import pkg.json as json
 
 class TestFix(pkg5unittest.SingleDepotTestCase):
 

--- a/src/tests/cli/t_pkg_avoid.py
+++ b/src/tests/cli/t_pkg_avoid.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from . import testutils
@@ -30,7 +31,7 @@ if __name__ == "__main__":
 import pkg5unittest
 import os
 
-import simplejson as json
+import pkg.json as json
 
 class TestPkgAvoid(pkg5unittest.SingleDepotTestCase):
         # Only start/stop the depot once (instead of for every test)

--- a/src/tests/cli/t_pkg_freeze.py
+++ b/src/tests/cli/t_pkg_freeze.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from . import testutils
@@ -30,11 +31,11 @@ if __name__ == "__main__":
 import pkg5unittest
 
 import os
-import simplejson as json
 import stat
 import time
 
 import pkg.client.api_errors as apx
+import pkg.json as json
 import pkg.fmri as fmri
 
 class TestPkgFreeze(pkg5unittest.SingleDepotTestCase):

--- a/src/tests/cli/t_pkg_verify.py
+++ b/src/tests/cli/t_pkg_verify.py
@@ -21,6 +21,7 @@
 #
 
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
 if __name__ == "__main__":
@@ -30,11 +31,12 @@ import pkg5unittest
 import os
 import pkg.portable as portable
 import shutil
-import simplejson as json
 import subprocess
 import tempfile
 import time
 import unittest
+
+import pkg.json as json
 
 class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
         # Tests in this suite use the read only data directory

--- a/src/tests/cli/t_pkgrecv.py
+++ b/src/tests/cli/t_pkgrecv.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from . import testutils
@@ -30,7 +31,6 @@ if __name__ == "__main__":
 import pkg5unittest
 
 import os
-import simplejson as json
 import six
 import pkg.catalog as catalog
 import pkg.config as cfg
@@ -51,6 +51,7 @@ import zlib
 
 from pkg.actions import fromstr
 from pkg.digest import DEFAULT_HASH_FUNC
+import pkg.json as json
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.request import url2pathname
 

--- a/src/tests/cli/t_pkgrepo.py
+++ b/src/tests/cli/t_pkgrepo.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from . import testutils
@@ -36,13 +37,13 @@ import pkg.catalog
 import pkg.manifest
 import pkg.depotcontroller as dc
 import pkg.fmri as fmri
-import pkg.pkggzip
+import pkg.json as json
 import pkg.misc as misc
+import pkg.pkggzip
 import pkg.server.repository as sr
 import pkg.client.api_errors as apx
 import pkg.p5p
 import shutil
-import simplejson as json
 import six
 import subprocess
 import tempfile
@@ -1622,34 +1623,34 @@ publisher\tprefix\texample.net
                         # json output.
                         self.pkgrepo("list -s {0} -F json".format(src))
                         expected = """\
-[{"branch": "0", "build-release": "5.11", "name": "amber", \
-"pkg.fmri": "pkg://test/amber@4.0,5.11-0:20110804T203458Z", \
-"pkg.obsolete": [{"value": ["true"]}], "publisher": "test", \
-"release": "4.0", "timestamp": "20110804T203458Z", \
-"version": "4.0,5.11-0:20110804T203458Z"}, \
-{"branch": "0", "build-release": "5.11", "name": "amber", \
-"pkg.fmri": "pkg://test/amber@3.0,5.11-0:20110804T203458Z", \
-"pkg.renamed": [{"value": ["true"]}], "publisher": "test", \
-"release": "3.0", "timestamp": "20110804T203458Z", \
-"version": "3.0,5.11-0:20110804T203458Z"}, \
-{"branch": "0", "build-release": "5.11", "name": "amber", \
-"pkg.fmri": "pkg://test/amber@2.0,5.11-0:20110804T203458Z", \
-"publisher": "test", "release": "2.0", "timestamp": "20110804T203458Z", \
-"version": "2.0,5.11-0:20110804T203458Z"}, \
-{"branch": "0", "build-release": "5.11", "name": "amber", \
-"pkg.fmri": "pkg://test/amber@1.0,5.11-0:20110804T203458Z", \
-"pkg.human-version": [{"value": ["1.0a"]}], \
-"pkg.summary": [{"value": ["Millenia old resin"]}], \
-"publisher": "test", "release": "1.0", "timestamp": "20110804T203458Z", \
-"version": "1.0,5.11-0:20110804T203458Z"}, \
-{"branch": "0", "build-release": "5.11", \
-"info.classification": [{"value": ["org.opensolaris.category.2008:System/Core"]}], \
-"name": "tree", "pkg.fmri": "pkg://test/tree@1.0,5.11-0:20110804T203458Z", \
-"pkg.summary": [{"value": ["Leafy SPARC package"], "variant.arch": ["sparc"]}, \
-{"value": ["Leafy i386 package"], "variant.arch": ["i386"]}], \
-"publisher": "test", "release": "1.0", "timestamp": "20110804T203458Z", \
-"variant.arch": [{"value": ["i386", "sparc"]}], \
-"version": "1.0,5.11-0:20110804T203458Z"}]"""
+[{"branch":"0","build-release":"5.11","name":"amber",\
+"pkg.fmri":"pkg://test/amber@4.0,5.11-0:20110804T203458Z",\
+"pkg.obsolete":[{"value":["true"]}],"publisher":"test",\
+"release":"4.0","timestamp":"20110804T203458Z",\
+"version":"4.0,5.11-0:20110804T203458Z"},\
+{"branch":"0","build-release":"5.11","name":"amber",\
+"pkg.fmri":"pkg://test/amber@3.0,5.11-0:20110804T203458Z",\
+"pkg.renamed":[{"value":["true"]}],"publisher":"test",\
+"release":"3.0","timestamp":"20110804T203458Z",\
+"version":"3.0,5.11-0:20110804T203458Z"},\
+{"branch":"0","build-release":"5.11","name":"amber",\
+"pkg.fmri":"pkg://test/amber@2.0,5.11-0:20110804T203458Z",\
+"publisher":"test","release":"2.0","timestamp":"20110804T203458Z",\
+"version":"2.0,5.11-0:20110804T203458Z"},\
+{"branch":"0","build-release":"5.11","name":"amber",\
+"pkg.fmri":"pkg://test/amber@1.0,5.11-0:20110804T203458Z",\
+"pkg.human-version":[{"value":["1.0a"]}],\
+"pkg.summary":[{"value":["Millenia old resin"]}],\
+"publisher":"test","release":"1.0","timestamp":"20110804T203458Z",\
+"version":"1.0,5.11-0:20110804T203458Z"},\
+{"branch":"0","build-release":"5.11",\
+"info.classification":[{"value":["org.opensolaris.category.2008:System/Core"]}],\
+"name":"tree","pkg.fmri":"pkg://test/tree@1.0,5.11-0:20110804T203458Z",\
+"pkg.summary":[{"value":["Leafy SPARC package"],"variant.arch":["sparc"]},\
+{"value":["Leafy i386 package"],"variant.arch":["i386"]}],\
+"publisher":"test","release":"1.0","timestamp":"20110804T203458Z",\
+"variant.arch":[{"value":["i386","sparc"]}],\
+"version":"1.0,5.11-0:20110804T203458Z"}]"""
                         self.assertEqualDiff(expected, self.output)
 
                 # Now verify list output in different formats but only using

--- a/src/tests/cli/t_sysrepo.py
+++ b/src/tests/cli/t_sysrepo.py
@@ -23,6 +23,7 @@
 
 #
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from . import testutils
@@ -39,7 +40,6 @@ import pkg.p5p
 import shutil
 import unittest
 import shutil
-import simplejson
 import six
 import stat
 import sys
@@ -49,6 +49,7 @@ from six.moves.urllib.parse import urlparse, unquote
 from six.moves.urllib.request import urlopen
 
 import pkg.misc as misc
+import pkg.json as json
 import pkg.portable as portable
 
 from pkg.digest import DEFAULT_HASH_FUNC
@@ -768,7 +769,7 @@ class TestDetailedSysrepoCli(pkg5unittest.ApacheDepotTestCase):
                 rubbish = {"food preference": "I like noodles."}
                 other = ["nonsense here"]
                 with open(full_cache_path, "w") as cache_file:
-                        simplejson.dump((rubbish, other), cache_file)
+                        json.dump((rubbish, other), cache_file)
                 self.sysrepo("", stderr=True)
                 self.assertTrue("Invalid config cache at" in self.errout)
                 self.file_doesnt_contain(cache_path, "noodles")
@@ -796,12 +797,12 @@ class TestDetailedSysrepoCli(pkg5unittest.ApacheDepotTestCase):
                 # same configuration as the image, simulating an older version
                 # of pkg(1) having changed publisher configuration.
                 with open(full_cache_path, "r") as cache_file:
-                        uri_pub_map, no_uri_pubs = simplejson.load(cache_file)
+                        uri_pub_map, no_uri_pubs = json.load(cache_file)
 
                 with open(full_cache_path, "w") as cache_file:
                         del uri_pub_map[self.durl1]
-                        simplejson.dump((uri_pub_map, no_uri_pubs), cache_file,
-                            indent=True)
+                        json.dump((uri_pub_map, no_uri_pubs), cache_file,
+                            indent=4)
                 # make sure we've definitely broken it
                 self.file_doesnt_contain(cache_path, self.durl1)
 

--- a/src/tests/pkg5unittest.py
+++ b/src/tests/pkg5unittest.py
@@ -20,6 +20,7 @@
 #
 
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 #
 # Define the basic classes that all test cases are inherited from.
@@ -49,7 +50,6 @@ import os
 import pprint
 import shutil
 import signal
-import simplejson as json
 import six
 import stat
 import subprocess
@@ -81,6 +81,7 @@ from six.moves.urllib.request import urlopen
 from socket import error as socketerror
 
 import pkg.client.api_errors as apx
+import pkg.json as json
 import pkg.misc as misc
 import pkg.client.publisher as publisher
 import pkg.portable as portable

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -22,12 +22,12 @@
 
 #
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
-# Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from __future__ import print_function
-import simplejson as json
 import multiprocessing
+import json as stdlibjson
 import os
 import sys
 from functools import reduce
@@ -443,7 +443,7 @@ if __name__ == "__main__":
         timing_history = os.path.join(os.getcwd(), ".timing_history.txt")
         if os.path.exists(timing_history):
                 with open(timing_history, "r") as fh:
-                        ver, time_estimates = json.load(fh)
+                        ver, time_estimates = stdlibjson.load(fh)
 
         api_suite = find_tests("api", onlyval, startattest, output,
             time_estimates)

--- a/src/util/apache2/sysrepo/sysrepo_p5p.py
+++ b/src/util/apache2/sysrepo/sysrepo_p5p.py
@@ -20,18 +20,19 @@
 # CDDL HEADER END
 #
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from __future__ import print_function
 import pkg.p5p
 
 import os
 import shutil
-import simplejson
 import six
 import sys
 import threading
 import traceback
 from six.moves import http_client
+import pkg.json as json
 from pkg.misc import force_str
 
 # redirecting stdout for proper WSGI portability
@@ -250,8 +251,8 @@ class SysrepoP5p(object):
                             pub=pub)
                         with open(os.path.join(cat_dir, "catalog.attrs"),
                             "rb") as catalog_attrs:
-                                json = simplejson.load(catalog_attrs)
-                                for part in json["parts"]:
+                                ret_json = json.load(catalog_attrs)
+                                for part in ret_json["parts"]:
                                         self.p5p.extract_catalog1(part, cat_dir,
                                             pub=pub)
 


### PR DESCRIPTION
I've only done limited testing on OpenIndiana for this but I wanted to share a change that we recently made in OmniOS IPS, which is to replace the `simplejson` library with `rapidjson`.  We also centralised the JSON parsing and schema checking into a new `pkg.json` module which makes it easier to drop in different JSON implementations if necessary. While rapidjson does provide schema validation, it didn't work in our testing so jsonschema is still used for that.

This followed some discussions at FOSDEM (thanks @Toasterson) about memory usage in IPS and in particular related to JSON parsing.

We evaluated a number of libraries including the standard python3 json module, the existing simplejson, rapidjson, orjson, ultrajson. We found that rapidjson uses about 20% less memory overall and is around 15% faster than simplejson for combined tasks such as a `pkg refresh --full` or `pkg list -a`. The other libraries were the same or worse than simplejson (and some are really hard to build on illumos too).

Here's an extract of the memory benchmarking showing the total RSS used when loading and parsing the OpenIndiana summary catalogue file, which is 77MiB as of today:

```
77.0M catalog.summary.C

rapidjson       233124K
orjson          363556K
stdlib          363672K
simplejson      364156K
hyperjson       413920K
```

and here are the testsuite results (obviously this requires `rapidjson-35` for which there is a draft PR at https://github.com/OpenIndiana/oi-userland/pull/5570 )

```
# Ran 1132 tests in 1807.478s - skipped 2 tests.

FAILED (successes=1129, failures=3, errors=0, mismatches=2)

======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
cli.t_pkg_sysrepo.py TestSysrepo.test_disabled_origins: fail
cli.t_pkg_depotd.py TestDepotOutput.test_0_depot_bui_output: fail
======================================================================
```
