### PR TITLE
Add Smalltalk to Development category

### DIFF
--- a/src/util/opensolaris.org.sections
+++ b/src/util/opensolaris.org.sections
@@ -31,7 +31,7 @@ category = Accessories,Configuration and Preferences,Games,Graphics and Imaging,
 category = Documentation,File Managers,Libraries,Localizations,Scripts,Sessions,Theming,Trusted Extensions,Window Managers
 
 [Development]
-category = C,C++,Databases,Distribution Tools,Editors,Fortran,GNOME and GTK+,GNU,High Performance Computing,Integrated Development Environments,Java,Objective C,Observability,Other Languages,PHP,Perl,Python,Ruby,Source Code Management,Suites,System,X11
+category = C,C++,Databases,Distribution Tools,Editors,Fortran,GNOME and GTK+,GNU,High Performance Computing,Integrated Development Environments,Java,Objective C,Observability,Other Languages,PHP,Perl,Python,Ruby,Smalltalk,Source Code Management,Suites,System,X11
 
 [Drivers]
 category = Display,Media,Networking,Other Peripherals,Ports,Storage


### PR DESCRIPTION
Add Smalltalk to /usr/share/lib/pkg/opensolaris.org.sections.
I am not sure whether this is all that is required to add a Development/Smalltalk category.