### PR TITLE
Check for duplicate legacy package names

### DIFF
--- a/src/modules/lint/pkglint_action.py
+++ b/src/modules/lint/pkglint_action.py
@@ -22,6 +22,7 @@
 
 #
 # Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
 from pkg.lint.engine import lint_fmri_successor
@@ -292,6 +293,16 @@ class PkgDupActionChecker(base.ActionChecker):
                     manifest.get_all_variants(), msgid=pkglint_id)
 
         duplicate_gids.pkglint_desc = _("GIDs should be unique.")
+
+        def duplicate_legacy(self, action, manifest, engine, pkglint_id="015"):
+                """Checks for duplicate legacy package names."""
+
+                self.dup_attr_check(["legacy"], "pkg", self.ref_legacy_pkgs,
+                    self.processed_refcount_legacy_pkgs, action, engine,
+                    manifest.get_all_variants(), msgid=pkglint_id)
+
+        duplicate_legacy.pkglint_desc = _(
+            "Legacy package names should be unique.")
 
         def duplicate_refcount_path_attrs(self, action, manifest, engine,
             pkglint_id="007"):


### PR DESCRIPTION
A package was recently committed to illumos-gate with a duplicate legacy package name which prevented installation. This updates `pkglint` to catch these errors.
I'm separately raising a change to gate to start using `pkglint` for illumos-gate packages.

```
ERROR pkglint.dupaction015.1      pkg SUNWmrsas is a duplicate delivered by pkg:/driver/network/mlxcx@0.5.11,5.11-151034.0 pkg:/driver/storage/mr_sas@0.5.11,5.11-151034.0 under all variant combinations
```
