### PR TITLE
Check for duplicate legacy package names (fix tests)

### DIFF
--- a/src/tests/api/t_pkglint.py
+++ b/src/tests/api/t_pkglint.py
@@ -451,7 +451,7 @@ link path=usr/bin/gcc target=foo/gcc-bin1
 hardlink path=usr/bin/gcc target=bar/gcc-bin1
 """
 
-expected_failures["dup-refcount-legacy.mf"] = ["pkglint.dupaction007"]
+expected_failures["dup-refcount-legacy.mf"] = ["pkglint.dupaction015.1"]
 broken_manifests["dup-refcount-legacy.mf"] = \
 """
 #
@@ -2882,7 +2882,8 @@ dir group=sys mode=0755 owner=root path=etc
                 lint_msgs = []
                 # prune out the missing dependency warnings
                 for msg in lint_logger.messages:
-                        if "pkglint.action005.1" not in msg:
+                        if ("pkglint.action005.1" not in msg
+                            and "pkglint.dupaction015.1" not in msg):
                                 lint_msgs.append(msg)
 
                 self.assertTrue(len(lint_msgs) == 0,
@@ -2924,7 +2925,8 @@ dir group=sys mode=0755 owner=root path=etc
                 lint_msgs = []
                 # prune out the missing dependency warnings
                 for msg in lint_logger.messages:
-                        if "pkglint.action005.1" not in msg:
+                        if ("pkglint.action005.1" not in msg
+                            and "pkglint.dupaction015.1" not in msg):
                                 lint_msgs.append(msg)
 
                 self.assertFalse(lint_msgs,
@@ -3110,7 +3112,8 @@ dir group=sys mode=0755 owner=root path=etc
 
                 lint_msgs = []
                 for msg in lint_logger.messages:
-                        if "pkglint.action005.1" not in msg:
+                        if ("pkglint.action005.1" not in msg
+                            and "pkglint.dupaction015.1" not in msg):
                                 lint_msgs.append(msg)
 
                 self.assertTrue(len(lint_msgs) == 2, "Unexpected lint messages "
@@ -3145,7 +3148,8 @@ dir group=sys mode=0755 owner=root path=etc
                 for msg in lint_logger.messages:
                         lint_msgs.append(msg)
 
-                self.assertTrue(len(lint_msgs) == 2, "Unexpected lint messages "
+                self.debug(lint_msgs)
+                self.assertTrue(len(lint_msgs) == 3, "Unexpected lint messages "
                     "produced when linting broken self-dependent renaming with "
                     "legacy pkgs")
                 seen_2_4 = False
@@ -3182,7 +3186,7 @@ dir group=sys mode=0755 owner=root path=etc
                         lint_msgs.append(msg)
 
                 self.debug(lint_msgs)
-                self.assertTrue(len(lint_msgs) == 0, "Unexpected lint messages "
+                self.assertTrue(len(lint_msgs) == 1, "Unexpected lint messages "
                     "produced when linting a compatibility legacy package")
 
                 # the 'legacy' package includes a legacy action which should
@@ -3202,7 +3206,7 @@ dir group=sys mode=0755 owner=root path=etc
                 for msg in lint_logger.messages:
                         lint_msgs.append(msg)
 
-                self.assertTrue(len(lint_msgs) == 0, "Unexpected lint messages "
+                self.assertTrue(len(lint_msgs) == 1, "Unexpected lint messages "
                     "produced when linting a compatibility legacy package")
 
         def test_relative_path(self):


### PR DESCRIPTION
e2751767fa73685643cf93f6ac7edf0d97cdab21 introduced a new lint action and unfortunately broke a few tests. Here is the fix.

I ran the test suite with this and here are the results:

```
FAILED (successes=1067, failures=3, errors=62, mismatches=66)

======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
cli.t_pkgrepo.py TestPkgRepo.test_10_list: pass
cli.t_pkg_sysrepo.py TestSysrepo.test_01_basics: error
cli.t_pkg_sysrepo.py TestSysrepo.test_01a_basics: error
cli.t_pkg_sysrepo.py TestSysrepo.test_02_communication: error
cli.t_pkg_sysrepo.py TestSysrepo.test_03_user_modifying_configuration: error
cli.t_pkg_sysrepo.py TestSysrepo.test_04_changing_syspub_configuration: error
cli.t_pkg_sysrepo.py TestSysrepo.test_05_simultaneous_change: error
cli.t_pkg_sysrepo.py TestSysrepo.test_06_ordering: error
cli.t_pkg_sysrepo.py TestSysrepo.test_07_environment_variable: error
cli.t_pkg_sysrepo.py TestSysrepo.test_08_file_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_09_test_file_http_transitions: error
cli.t_pkg_sysrepo.py TestSysrepo.test_10_test_mirrors: error
cli.t_pkg_sysrepo.py TestSysrepo.test_11_https_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_11a_https_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_12_disabled_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_12a_disabled_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_13_no_url: error
cli.t_pkg_sysrepo.py TestSysrepo.test_13a_no_url: error
cli.t_pkg_sysrepo.py TestSysrepo.test_automatic_refresh: error
cli.t_pkg_sysrepo.py TestSysrepo.test_bug_18326: error
cli.t_pkg_sysrepo.py TestSysrepo.test_catalog_is_not_cached_file: error
cli.t_pkg_sysrepo.py TestSysrepo.test_catalog_is_not_cached_http: error
cli.t_pkg_sysrepo.py TestSysrepo.test_disabled_origins: error
cli.t_pkg_sysrepo.py TestSysrepo.test_no_unnecessary_refresh: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_1: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_2: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_3: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_4: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_5: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_6: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_7: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_8: error
cli.t_pkg_sysrepo.py TestSysrepo.test_syspub_toggle: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_12_cache_dir_permissions: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_13_changing_p5p: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_14_bad_input: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_15_unicode: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_17_proxy: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_3_cache_dir: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_4_logs_dir: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_5_port_host: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_7_response_overlaps: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_8_file_publisher: error
cli.t_depot_config.py TestHttpDepot.test_0_htdepot: error
cli.t_depot_config.py TestHttpDepot.test_11_htbui: error
cli.t_depot_config.py TestHttpDepot.test_12_htpkgclient: error
cli.t_depot_config.py TestHttpDepot.test_13_htpkgrecv: error
cli.t_depot_config.py TestHttpDepot.test_14_htpkgrepo: error
cli.t_depot_config.py TestHttpDepot.test_15_htheaders: error
cli.t_depot_config.py TestHttpDepot.test_16_htfragment: error
cli.t_pkg_history.py TestPkgHistory.test_14_history_unicode_locale: fail
cli.t_sysrepo.py TestBasicSysrepoCli.test_0_sysrepo: error
cli.t_depot_config.py TestHttpsDepot.test_5_https_gen_cert: error
cli.t_depot_config.py TestHttpsDepot.test_6_https_cert_chain: error
cli.t_depot_config.py TestHttpsDepot.test_7_https_provided_ca: error
cli.t_pkg_depotd.py TestDepotOutput.test_0_depot_bui_output: fail
cli.t_pkg_linked.py TestPkgLinked2.test_linked_sync_via_update: fail
cli.t_https.py TestHTTPS.test_01_basics: error
cli.t_https.py TestHTTPS.test_correct_cert_validation: error
cli.t_https.py TestHTTPS.test_expired_certs: error
cli.t_https.py TestHTTPS.test_expiring_certs: error
cli.t_pkg_install.py TestPkgInstallApache.test_corrupt_web_cache: error
cli.t_pkg_install.py TestPkgInstallApache.test_granular_proxy: error
cli.t_pkgrecv.py TestPkgrecvHTTPS.test_01_basics: error
cli.t_pkgrepo.py TestPkgrepoHTTPS.test_01_basics: error
cli.t_pkgsend.py TestPkgsendHTTPS.test_01_basics: error
======================================================================
