### PR TITLE
pkgdepend generate occasionally fails to simplify variants

### DIFF
--- a/src/modules/variant.py
+++ b/src/modules/variant.py
@@ -464,10 +464,10 @@ class VariantCombinations(object):
                         for variant_name in sorted(self.__simpl_template,
                             reverse=True):
                                 def exclude_name(item):
-                                        return [
+                                        return sorted([
                                             (k, v) for k, v in item
                                             if k != variant_name
-                                        ]
+                                        ])
                                 # For sanity, instead of modifying rel_set on
                                 # the fly, a new working set is created to which
                                 # members or collapsed members of rel_set are


### PR DESCRIPTION
This is a fix for a subtle bug in `pkgdepend` that showed up when I was testing my change to add pkglint to illumos-gate builds.

Occasionally, `pkgdepend generate` fails to properly collapse the variant set and outputs extra dependency lines. In my testing, it happens around once in every 20 illumos-gate builds and produces packages that work, but are technically incorrect and fail a `pkglint`.

This happens because the variant calculation code groups variants based on a list generated from a set, but since it's a set its order is not guaranteed.
Sorting the resulting list key resolves the problem.

Test suite results - not sure what's normally expected here, the mismatches look a bit long!
(FWIW, this change made no difference to the test results on OmniOS)

```
# ----------------------------------------------------------------------

# Ran 1132 tests in 2911.195s - skipped 2 tests.

FAILED (successes=1067, failures=3, errors=62, mismatches=64)

======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
cli.t_sysrepo.py TestDetailedSysrepoCli.test_12_cache_dir_permissions: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_13_changing_p5p: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_14_bad_input: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_15_unicode: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_17_proxy: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_3_cache_dir: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_4_logs_dir: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_5_port_host: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_7_response_overlaps: error
cli.t_sysrepo.py TestDetailedSysrepoCli.test_8_file_publisher: error
cli.t_pkg_sysrepo.py TestSysrepo.test_01_basics: error
cli.t_pkg_sysrepo.py TestSysrepo.test_01a_basics: error
cli.t_pkg_sysrepo.py TestSysrepo.test_02_communication: error
cli.t_pkg_sysrepo.py TestSysrepo.test_03_user_modifying_configuration: error
cli.t_pkg_sysrepo.py TestSysrepo.test_04_changing_syspub_configuration: error
cli.t_pkg_sysrepo.py TestSysrepo.test_05_simultaneous_change: error
cli.t_pkg_sysrepo.py TestSysrepo.test_06_ordering: error
cli.t_pkg_sysrepo.py TestSysrepo.test_07_environment_variable: error
cli.t_pkg_sysrepo.py TestSysrepo.test_08_file_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_09_test_file_http_transitions: error
cli.t_pkg_sysrepo.py TestSysrepo.test_10_test_mirrors: error
cli.t_pkg_sysrepo.py TestSysrepo.test_11_https_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_11a_https_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_12_disabled_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_12a_disabled_repos: error
cli.t_pkg_sysrepo.py TestSysrepo.test_13_no_url: error
cli.t_pkg_sysrepo.py TestSysrepo.test_13a_no_url: error
cli.t_pkg_sysrepo.py TestSysrepo.test_automatic_refresh: error
cli.t_pkg_sysrepo.py TestSysrepo.test_bug_18326: error
cli.t_pkg_sysrepo.py TestSysrepo.test_catalog_is_not_cached_file: error
cli.t_pkg_sysrepo.py TestSysrepo.test_catalog_is_not_cached_http: error
cli.t_pkg_sysrepo.py TestSysrepo.test_disabled_origins: error
cli.t_pkg_sysrepo.py TestSysrepo.test_no_unnecessary_refresh: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_1: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_2: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_3: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_4: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_5: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_6: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_7: error
cli.t_pkg_sysrepo.py TestSysrepo.test_signature_policy_8: error
cli.t_pkg_sysrepo.py TestSysrepo.test_syspub_toggle: error
cli.t_pkg_history.py TestPkgHistory.test_14_history_unicode_locale: fail
cli.t_sysrepo.py TestBasicSysrepoCli.test_0_sysrepo: error
cli.t_pkg_depotd.py TestDepotOutput.test_0_depot_bui_output: fail
cli.t_depot_config.py TestHttpsDepot.test_5_https_gen_cert: error
cli.t_depot_config.py TestHttpsDepot.test_6_https_cert_chain: error
cli.t_depot_config.py TestHttpsDepot.test_7_https_provided_ca: error
cli.t_https.py TestHTTPS.test_01_basics: error
cli.t_https.py TestHTTPS.test_correct_cert_validation: error
cli.t_https.py TestHTTPS.test_expired_certs: error
cli.t_https.py TestHTTPS.test_expiring_certs: error
cli.t_pkg_install.py TestPkgInstallApache.test_corrupt_web_cache: error
cli.t_pkg_install.py TestPkgInstallApache.test_granular_proxy: error
cli.t_pkgrecv.py TestPkgrecvHTTPS.test_01_basics: error
cli.t_pkgrepo.py TestPkgrepoHTTPS.test_01_basics: error
cli.t_pkgsend.py TestPkgsendHTTPS.test_01_basics: error
cli.t_depot_config.py TestHttpDepot.test_0_htdepot: error
cli.t_depot_config.py TestHttpDepot.test_11_htbui: error
cli.t_depot_config.py TestHttpDepot.test_12_htpkgclient: error
cli.t_depot_config.py TestHttpDepot.test_13_htpkgrecv: error
cli.t_depot_config.py TestHttpDepot.test_14_htpkgrepo: error
cli.t_depot_config.py TestHttpDepot.test_15_htheaders: error
cli.t_depot_config.py TestHttpDepot.test_16_htfragment: error
======================================================================
```