### PR TITLE
Add quotes around macro-based values

### DIFF
--- a/src/modules/actions/generic.py
+++ b/src/modules/actions/generic.py
@@ -314,7 +314,8 @@ class Action(object):
                                     "=".join((k, quote_attr_value(lmt)))
                                     for lmt in v
                                 ])
-                        elif " " in v or "'" in v or "\"" in v or v == "":
+                        # Quote values containing whitespaces or macros
+                        elif " " in v or "'" in v or "\"" in v or v == "" or "$(" in v:
                                 if "\"" not in v:
                                         out += " " + k + "=\"" + v + "\""
                                 elif "'" not in v:
@@ -352,7 +353,7 @@ class Action(object):
                         out += " " + self.hash
 
                 def q(s):
-                        if " " in s or "'" in s or "\"" in s or s == "":
+                        if " " in s or "'" in s or "\"" in s or s == "" or "$(" in s:
                                 if "\"" not in s:
                                         return '"{0}"'.format(s)
                                 elif "'" not in s:
@@ -375,7 +376,7 @@ class Action(object):
                                 out += " " + " ".join([
                                     "{0}={1}".format(k, q(lmt)) for lmt in sorted(v)
                                 ])
-                        elif " " in v or "'" in v or "\"" in v or v == "":
+                        elif " " in v or "'" in v or "\"" in v or v == "" or "$(" in v:
                                 if "\"" not in v:
                                         out += " " + k + "=\"" + v + "\""
                                 elif "'" not in v:

--- a/src/tests/cli/t_pkgmogrify.py
+++ b/src/tests/cli/t_pkgmogrify.py
@@ -51,10 +51,10 @@ dir group=bin mode=0755 owner=root path=usr/X11/bin
 dir group=bin mode=0755 owner=root path=usr/X11/include
 dir group=bin mode=0755 owner=root path=usr/X11/include/X11
 # dependencies
-depend fmri=SUNWfontconfig@2.7.1-$(BUILDID) type=require
-depend fmri=SUNWfreetype2@2.3.9-$(BUILDID) type=require
-depend fmri=SUNWlibms@0.5.11-$(BUILDID) type=require
-$(i386_ONLY)depend fmri=SUNWxorg-mesa@7.4.4-$(BUILDID) type=require
+depend fmri="SUNWfontconfig@2.7.1-$(BUILDID)" type=require
+depend fmri="SUNWfreetype2@2.3.9-$(BUILDID)" type=require
+depend fmri="SUNWlibms@0.5.11-$(BUILDID)" type=require
+$(i386_ONLY)depend fmri="SUNWxorg-mesa@7.4.4-$(BUILDID)" type=require
 file NOHASH elfarch=i386 elfbits=32 group=bin mode=0755 \
 owner=root path=usr/X11/bin/xkbprint
 file NOHASH group=bin mode=0755 owner=root path=usr/X11/bin/Xserver


### PR DESCRIPTION
A less intrusive change than #84 but with the desired effect.

```
======================================================================
FAIL: cli.t_pkgmogrify.py TestPkgMogrify.test_10
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./pkg5unittest.py", line 764, in run
    testMethod()
  File "./api/../cli/t_pkgmogrify.py", line 440, in test_10
    coverage=False)
  File "./pkg5unittest.py", line 522, in cmdline_run
    comment)
pkg5unittest.UnexpectedExitCodeException:
  Invoked:   diff /tmp/ips.test.23327/0/source_file /tmp/ips.test.23327/0/output_file
  Expected exit status: [0].  Got: 1.  Output Follows:
,---------------------------------------------------------------------
| $   diff /tmp/ips.test.23327/0/source_file /tmp/ips.test.23327/0/output_file
| 7,10c7,10
| < depend fmri=SUNWfontconfig@2.7.1-$(BUILDID) type=require
| < depend fmri=SUNWfreetype2@2.3.9-$(BUILDID) type=require
| < depend fmri=SUNWlibms@0.5.11-$(BUILDID) type=require
| < $(i386_ONLY)depend fmri=SUNWxorg-mesa@7.4.4-$(BUILDID) type=require
| ---
| > depend fmri="SUNWfontconfig@2.7.1-$(BUILDID)" type=require
| > depend fmri="SUNWfreetype2@2.3.9-$(BUILDID)" type=require
| > depend fmri="SUNWlibms@0.5.11-$(BUILDID)" type=require
| > $(i386_ONLY)depend fmri="SUNWxorg-mesa@7.4.4-$(BUILDID)" type=require
|
`---------------------------------------------------------------------


# ----------------------------------------------------------------------

# Ran 1132 tests in 10862.353s - skipped 1 tests.

FAILED (successes=1131, failures=1, errors=0, mismatches=2)

======================================================================
BASELINE MISMATCH: The following results didn't match the baseline.
----------------------------------------------------------------------
cli.t_pkgrepo.py TestPkgRepo.test_10_list: pass
cli.t_pkgmogrify.py TestPkgMogrify.test_10: fail
======================================================================

```

After the test change:

```
# python3.5 run.py -v  -o cli.t_pkgmogrify
# Loading api tests:
 #         t_action t_altroot t_api t_api_info t_api_list t_api_refresh
#         t_api_search t_async_rpc t_bootenv t_catalog t_client t_config
#         t_dependencies t_elf t_file_manager t_fmri t_history t_imageconfig
#         t_indexer t_linked_image t_manifest t_misc t_p5i t_p5p
#         t_pkg_api_fix t_pkg_api_hydrate t_pkg_api_install t_pkg_api_revert
#         t_pkglint t_pkgtarfile t_plat t_printengine t_progress t_publisher
#         t_sha512_t t_smf t_solver t_sysattr t_unix_usergrp t_variant
#         t_version
#
 # Loading cli tests:
 #         t_actuators t_change_facet t_change_variant t_client_api
#         t_colliding_links t_depot_config t_fix t_https t_lock t_origin_fw
#         t_pkg_R_option t_pkg_avoid t_pkg_composite t_pkg_contents
#         t_pkg_depotd t_pkg_errors t_pkg_freeze t_pkg_help t_pkg_history
#         t_pkg_hydrate t_pkg_image_create t_pkg_image_update t_pkg_info
#         t_pkg_initinstall t_pkg_install t_pkg_intent t_pkg_linked
#         t_pkg_list t_pkg_mediated t_pkg_modified t_pkg_nasty t_pkg_property
#         t_pkg_publisher t_pkg_rebuild_index t_pkg_refresh t_pkg_revert
#         t_pkg_search t_pkg_sysrepo t_pkg_temp_sources t_pkg_terminal
#         t_pkg_uninstall t_pkg_varcet t_pkg_verify t_pkg_version t_pkgdep
#         t_pkgdep_resolve t_pkgdiff t_pkgfmt t_pkglint t_pkgmerge
#         t_pkgmogrify t_pkgrecv t_pkgrepo t_pkgsend t_pkgsign t_pkgsurf
#         t_publish_api t_sysrepo t_util_merge t_util_update_file_layout
#         t_variants
#
 # logging to /tmp/tmp6259_w0b.pkg-test.log
cli.t_pkgmogrify.py TestPkgMogrify.test_1                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_10                         match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_11                         match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_12                         match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_13                         match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_14                         match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_2                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_3                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_4                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_5                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_6                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_7                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_8                          match pass
cli.t_pkgmogrify.py TestPkgMogrify.test_9                          match pass

# Ran 14 tests in 20.976s - skipped 0 tests.


======================================================================
BASELINE MATCH
======================================================================

```


