### PR TITLE
Wrong format specified for memory usage

### DIFF
--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -1039,7 +1039,7 @@ def out_of_memory():
         try:
                 vmusage = __getvmusage()
                 if vmusage is not None:
-                        vsz = bytes_to_str(vmusage, fmt="{num}.0f{unit}")
+                        vsz = bytes_to_str(vmusage, fmt="{num:.0f}{unit}")
         except (MemoryError, EnvironmentError) as __e:
                 if isinstance(__e, EnvironmentError) and \
                     __e.errno != errno.ENOMEM:


### PR DESCRIPTION
Reported by woodstock on IRC

```
pkg: There is not enough memory to complete the requested operation.  At least
1.31.0fGB of virtual memory was in use by this command before it ran out of memory.
```