### PR TITLE
Add protection against creating user and/or group with fixed IDs already used on the system

### DIFF
--- a/src/modules/actions/group.py
+++ b/src/modules/actions/group.py
@@ -80,16 +80,21 @@ class GroupAction(generic.Action):
 
                 gr = GroupFile(pkgplan.image)
 
+                # Read group attrs from on-disk data, if any
                 cur_attrs = gr.getvalue(template)
 
-                # check for (wrong) pre-existing definition
+                # check for (maybe wrong) pre-existing definition
                 # if so, rewrite entry using existing defs but new group entry
                 #        (XXX this doesn't chown any files on-disk)
                 # else, nothing to do
                 if cur_attrs:
+                        # ...if the definition existed on-disk
                         if "gid" not in self.attrs:
+                                # ...if the pkg action did not require a gid number
                                 self.attrs["gid"] = cur_attrs["gid"]
                         elif self.attrs["gid"] != cur_attrs["gid"]:
+                                # ...if the pkg action required a gid number and
+                                # it differs from on-disk for same group name
                                 cur_gid = cur_attrs["gid"]
                                 template = cur_attrs;
                                 template["gid"] = self.attrs["gid"]

--- a/src/modules/cfgfiles.py
+++ b/src/modules/cfgfiles.py
@@ -137,21 +137,27 @@ class CfgFile(object):
         vals = []
         for valkey in self.index:
             val = self.index.get(valkey)[1]
-            #print("[D] val: ", val)
+            if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
+                print("[D] val: ", val)
             hit = None
             for k in template:
-                #print("[D]     key: %s\tseekval: %s" % (k, template[k]))
+                if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
+                    print("[D]     key: %s\tseekval: %s" % (k, template[k]))
                 if k in val:
-                    #print("    val[k]: %s" % (val[k]))
+                    if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
+                        print("    val[k]: %s" % (val[k]))
                     ### str() allows e.g. uid in template to be a numeric type
                     if str(val[k]) == str(template[k]) and hit is not False:
-                        #print("[D]     HAVE A HIT!")
+                        if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
+                            print("[D]     HAVE A HIT!")
                         hit = True
                     else:
-                        #print("[D]     LOST A HIT (val[k] mismatched)")
+                        if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
+                            print("[D]     LOST A HIT (val[k] mismatched)")
                         hit = False
                 else:
-                    #print("[D]     LOST A HIT (k not in val)")
+                    if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
+                        print("[D]     LOST A HIT (k not in val)")
                     hit = False
             if hit:
                 vals.append(val)


### PR DESCRIPTION
Avoid breaking end-user deployments with new/updated packages that deliver a new name into an existing uid/gid entry (and require a particular fixed ID for that) by failing the package action. This actually implements the "spec requirements" from documentation stored in this project, that IPS actions for user/group with a specified uid/gid attribute must use that value as the unique identifier for the entity's name... *that* value and *unique*. Not much leeway for anything other than such a PR.

It also happened to open a discussion of what to do when there is a collision, and a newly installed or upgraded package happens to require an ID that is already used by a different and unrelated account name. This may happen if some packages were installed that had a user/group action without a specific ID so used a first available number under 100, or when/if packages (distro, custom...) are delivered which use specific IDs above 100 with a potential to collide with ordinary user accounts created per current `useradd` defaults.

Technically admins can manually add an alias entry into their file-based account databases or rename the existing account (if that fits the situation -- if the account is intended for this packaged software but was named differently earlier) to avoid the discrepancy, or evacuate the account by changing the ID in database and chown/chgrp the filesystem objects. Messages to this effect are logged by the `pkg(5)` tool, e.g.:

````
pkg: Requested operation failed for package pkg://oi-userland-jim/developer/jenkins-common@2.65,5.11-2020.0.1.3:20210416T191753Z:
User named 'jenkinsagent' cannot be installed. Requested UID number '399' is already
 occupied by ['abuild']. Please evacuate that user to another ID first (including FS
 object ownership), or rename (or alias) the account to the new packaged name if
 applicable.
````

* Before this change, `pkg` effectively created the alias with a new name to an existing ID in the file-backed account database. This could potentially lead to operating surprises, security breaches, or worse.

This protection also allows distributions to use reserved IDs above 100 in packaging cases where fixed IDs are deemed a necessity, with peace of mind that existing systems' data would avoid surprises if a user account exists with the numeric ID now desired by a system package.

Note that per https://github.com/OpenIndiana/pkg5/blob/oi/src/modules/cfgfiles.py#L334 and https://github.com/OpenIndiana/pkg5/blob/oi/doc/dev-guide/chpt3.txt#L908, and https://github.com/OpenIndiana/pkg5/blob/oi/src/modules/cfgfiles.py#L280 and https://github.com/OpenIndiana/pkg5/blob/oi/doc/dev-guide/chpt3.txt#L822, currently packages which define user and group actions without a specific ID would use the first one under 100 available on the system at the moment of installation (and would abort installation if all numbers are occupied).

Beside limiting the amount of uniquely named service accounts, with or without specific numbers (under 100) assigned in the packaging manifest, with current codebase this also opens the door to collisions where a package with a user/group action and without a specific uid/gid requirement can be installed first, and grabs an available ID number, and then another package requiring that number would get installed and potentially confuse the activity or compromise security of the two unrelated softwares. (I've checked the recipes in oi-userland, they seem safe from in-distro collisions: anything that defines a new user or group action, requires a specific ID for it. Other IPS-based distributions should check for this before picking up this changeset into their `pkg5`.)

The document cited above also states that if specified, the attribute is "The unique numeric ID of the (entity)" and this PR ensures that it would indeed be unique, or rather that `pkg` itself would not not make it ambiguous (end users can do so if needed to avoid the perceived conflict, but then it is on their responsibility).

Note: In a separate effort, per discussion on IRC, illumos in general or distributions in particular may want to bump the starting "normal" user ID to 1000 to match common Linux distro defaults, or 1001 to match BSD. And to make these numbers configurable... if/when addressed, this should be reflected in code and docs noted above.

Yet another note: to avoid the majority of surprise (required account "evacuation") on existing systems, packages probably should not require IDs between 100 and 150 or 200 (arbitrary example) in the nearby years while the range up to 1000 suffices, since the numbers shortly after 100 may be occupied by users of smaller deployments (home users, small companies). Larger deployments would likely use LDAP or similar database to coordinate many systems, and following modern best practices dictated by multiple OSes and/or schema defaults, so would less likely have many IDs defined between 100 and 1000.

UPDATE: Following some inputs from the discussion on IRC, a possibly future-safe(r) similar approach would be to not only "reserve" (consume last when time comes, if ever) some lower UIDs/GIDs just above 100, but also some range just under 1000 since many people and custom packages have their accounts in the 990's range. This way it makes sense to start new higher-numbered reservations for system packages from, for example, 800 and go down to 200, unless there is a good case for particular number to be used out of such order (e.g. compatibility with another popular distribution). It may take ages to fill those hundreds of reserved UIDs, giving us time to think about next steps and giving practically deployed systems years to get redeployed with new best practices and defaults applied, and/or indeed have their account numbers actively "evacuated" to another range.

Another point in these discussions was whether such evacuation should be aided or perpetrated by software, pkg or otherwise. My own stance is that we can provide the tools to change IDs in the account databases and re-own filesystem objects -- that's not difficult per se -- but that every situation is different and a human should pull the trigger. For example, in distributed systems it may be possible that e.g. NAS or NFS/LOFS-served homedir objects are owned by particular UIDs so the change has to be coherent across many operating environments (remote systems, local zones, VMs, etc.). In other cases system or non-system software and custom scriptware might have configurations or mappings written out to particular ID numbers and not string names, which is something that centralized software like `pkg` may be never in position to know about, but the particular system's manager should take into account. Beside "live" filesystem representation, there may also be a matter of backup archives and snapshots created back when the user accounts had their older UIDs/GIDs, which may be or not be a headache.