### PR TITLE
31244860 pkgsurf should allow not locking the reference repo

### DIFF
--- a/src/tests/cli/t_pkgfmt.py
+++ b/src/tests/cli/t_pkgfmt.py
@@ -20,7 +20,7 @@
 # CDDL HEADER END
 #
 #
-# Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
 #
 
 from . import testutils
@@ -1020,6 +1020,14 @@ driver name=intel_nb5000 alias=pci8086,25c0 alias=pci8086,25d0 alias=pci8086,25d
 # alphabetically or asciibetically.
 driver alias=usb1044,800a alias=usb13b1,20 alias=usb148f,2573 alias=usb15a9,4 alias=usb7d1,3c03 alias=usb7d1,3c04 alias=usbb05,1723 clone_perms="rum 0666 root sys" name=rum perms="* 0666 root sys" variant.arch=i386
 
+# Ensure the correct sorting for an alias that does not fit with the main
+# searching aliases meaning it falls to an alphabetical sort.
+driver name=usbser_edge perms="* 0666 root sys" alias=usbif1608,1.config1.0 alias=usbif1608,1.100.config1.0 alias=usbif1608,3.config1.0 alias=usbif1608,4.config1.0 alias=usbif1608,5.config1.0 alias=usbif1608,6.config1.0
+
+# Ensure the correct sorting for an alias that does not fit with the main
+# searching aliases meaning it falls to an alphabetical sort.
+driver name=usbvc perms="* 0666 root sys" alias=usbia46d,8c1.config1.0 alias=usbia46d,8c5.config1.0 alias=usbia46d,8c2.config1.0 alias=usbia,classe alias=usbia46d,8c3.config1.0
+
 # This driver's attributes should appear in the order: name, perms, clone_perms,
 # privs, policy, devlink, alias.
 driver name=driver alias="bobcat" clone_perms="driver 0666 root sys" devlink=type=ddi_pseudo;name=sv\\t\\D perms="driver 0666 root sys" policy="write_priv_set=net_rawaccess" privs=sys_config
@@ -1120,6 +1128,25 @@ driver name=rum clone_perms="rum 0666 root sys" perms="* 0666 root sys" \\
     alias=usb7d1,3c03 \\
     alias=usb7d1,3c04 \\
     alias=usbb05,1723 variant.arch=i386
+
+# Ensure the correct sorting for an alias that does not fit with the main
+# searching aliases meaning it falls to an alphabetical sort.
+driver name=usbser_edge perms="* 0666 root sys" \\
+    alias=usbif1608,1.100.config1.0 \\
+    alias=usbif1608,1.config1.0 \\
+    alias=usbif1608,3.config1.0 \\
+    alias=usbif1608,4.config1.0 \\
+    alias=usbif1608,5.config1.0 \\
+    alias=usbif1608,6.config1.0
+
+# Ensure the correct sorting for an alias that does not fit with the main
+# searching aliases meaning it falls to an alphabetical sort.
+driver name=usbvc perms="* 0666 root sys" \\
+    alias=usbia,classe \\
+    alias=usbia46d,8c1.config1.0 \\
+    alias=usbia46d,8c2.config1.0 \\
+    alias=usbia46d,8c3.config1.0 \\
+    alias=usbia46d,8c5.config1.0
 file path=etc/example group=root mode=0755 owner=root facet.devel=true \\
     variant.arch=i386
 
@@ -1266,6 +1293,25 @@ driver name=rum perms="* 0666 root sys" clone_perms="rum 0666 root sys" \\
     alias=usb13b1,20 \\
     alias=usb148f,2573 \\
     alias=usb15a9,4 variant.arch=i386
+
+# Ensure the correct sorting for an alias that does not fit with the main
+# searching aliases meaning it falls to an alphabetical sort.
+driver name=usbser_edge perms="* 0666 root sys" \\
+    alias=usbif1608,1.100.config1.0 \\
+    alias=usbif1608,1.config1.0 \\
+    alias=usbif1608,3.config1.0 \\
+    alias=usbif1608,4.config1.0 \\
+    alias=usbif1608,5.config1.0 \\
+    alias=usbif1608,6.config1.0
+
+# Ensure the correct sorting for an alias that does not fit with the main
+# searching aliases meaning it falls to an alphabetical sort.
+driver name=usbvc perms="* 0666 root sys" \\
+    alias=usbia46d,8c1.config1.0 \\
+    alias=usbia46d,8c2.config1.0 \\
+    alias=usbia46d,8c3.config1.0 \\
+    alias=usbia46d,8c5.config1.0 \\
+    alias=usbia,classe
 legacy pkg=SUNWipkg arch=i386 category=system \\
     desc="The Image Packaging System (IPS), or pkg(5), is the software delivery system used on OpenSolaris systems.  This package contains the core command-line components and depot server." \\
     hotline="Please contact your local service provider" \\

--- a/src/util/publish/pkgfmt.py
+++ b/src/util/publish/pkgfmt.py
@@ -295,7 +295,7 @@ def cmplines(a, b):
                         b_sk = b[0].attrs[key_attr]
 
                 c = misc.cmp(a_sk, b_sk)
-                # misc.cmp raises NotImplemented for uncomparable types in
+                # misc.cmp returns NotImplemented for uncomparable types in
                 # Python 3. Sort them based on stringified key attribute.
                 if c is NotImplemented:
                         c = misc.cmp(str(a_sk), str(b_sk))
@@ -458,7 +458,14 @@ def write_line(line, fileobj):
                         # Simple comparison for V1 format.
                         return misc.cmp(a, b)
                 # For V2 format, order aliases by interpreted value.
-                return misc.cmp(get_alias_key(a), get_alias_key(b))
+                c = misc.cmp(get_alias_key(a), get_alias_key(b))
+                # misc.cmp returns NotImplemented for uncomparable types in
+                # Python 3. Instead fallback to using the string of the key
+                # generated from the alias and sort alphabetically. This
+                # maintains the python 2 sorting behaviour.
+                if c is NotImplemented:
+                    c = -misc.cmp(str(get_alias_key(a)), str(get_alias_key(b)))
+                return c
 
         def astr(aout):
                 # Number of attribute values for first line and remaining.

--- a/src/util/publish/pkgsurf.py
+++ b/src/util/publish/pkgsurf.py
@@ -824,7 +824,11 @@ def main_func():
         ref = publisher.RepositoryURI(misc.parse_uri(ref_repo_uri))
         if ref.scheme == "file":
                 try:
-                        ref_repo = sr.Repository(read_only=dry_run,
+                        # It is possible that the client does not
+                        # have write access to the reference repo
+                        # so open it read-only to prevent the
+                        # attempt to create a lock file in it.
+                        ref_repo = sr.Repository(read_only=True,
                             root=ref.get_pathname())
                 except sr.RepositoryError as e:
                         abort(str(e))


### PR DESCRIPTION
31288050 drivers aliases without numbers cause pkgfmt to die


This cherry-picks the change (via omnios) that fixes the illumos build.  I haven't teste further than isolating and cherry-picking it, I would strongly recommend merging with omnios/talking with andyf