### PR TITLE
Id collision test fails

### DIFF
--- a/src/modules/cfgfiles.py
+++ b/src/modules/cfgfiles.py
@@ -143,7 +143,7 @@ class CfgFile(object):
             for k in template:
                 if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
                     print("[D]     key: %s\tseekval: %s" % (k, template[k]))
-                if k in val:
+                if val is not None and k in val:
                     if "PKG_ACCOUNTS_DEBUG" in os.environ and os.environ["PKG_ACCOUNTS_DEBUG"] == "verbose":
                         print("    val[k]: %s" % (val[k]))
                     ### str() allows e.g. uid in template to be a numeric type

--- a/src/tests/cli/t_pkg_install.py
+++ b/src/tests/cli/t_pkg_install.py
@@ -1440,7 +1440,7 @@ rpool/fail/fail2	{root}/fail2	zfs	dev=0	0
                 self.pkg("install b2", exit=1)
                 # this should pass because var/pkg/config is not reserved
                 self.pkg("install b3", exit=0)
-                
+
                 if portable.osname != "sunos":
                         return
                 self.pkg("install b4", exit=1)
@@ -6249,7 +6249,7 @@ adm:NP:6445::::::
                 self.pkg("verify simpleuser")
 
                 # remove the user from /etc/passwd
-                pdata[-1] = "misswiggy:x:5:0:& loves Kermie:/:"
+                pdata[-1] = ""
                 with open(ppath, "w") as f:
                         f.writelines(pdata)
                 self.pkg("verify simpleuser", exit=1)
@@ -6260,8 +6260,8 @@ adm:NP:6445::::::
                 self.pkg("verify simpleuser")
 
                 # remove the user completely
-                pdata[-1] = "misswiggy:x:5:0:& loves Kermie:/:"
-                sdata[-1] = "misswiggy:*LK*:14579::::::"
+                pdata[-1] = ""
+                sdata[-1] = ""
                 with open(ppath, "w") as f:
                         f.writelines(pdata)
                 with open(spath, "w") as f:
@@ -6296,6 +6296,7 @@ adm:NP:6445::::::
                 # verify that upgrading package to version that implicitly
                 # uses *LK* default causes password to change and that it
                 # verifies correctly
+
                 self.pkg("update simpleuser2@2")
                 self.pkg("verify simpleuser2")
                 with open(spath) as f:

--- a/src/tests/cli/t_pkg_search.py
+++ b/src/tests/cli/t_pkg_search.py
@@ -979,9 +979,11 @@ adm:NP:6445::::::
                 self.pkg("install fat")
                 self.pkg("install empty")
                 self.__run_empty_attrs_searches(remote=False)
+                # We skew the group/gid by 5 to avoid collisions with the
+                # misc_files etc/group
                 for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 1):
                         self.pkgsend_bulk(durl, self.empty_attr_pkg10_templ.format(
-                            ver=i))
+                            ver=i+5))
                 self.pkg("install 'empty*'")
                 self.pkg("search 'empty*'")
 


### PR DESCRIPTION
This fixes test failures introduced by the ID collision detection OI added.

@jimklimov can you check that I'm doing the right things here?  If it's possible, could you also add some tests for what you did?  It should be pretty easy to do.