### PR TITLE
test failure fixes from andyf

### DIFF
--- a/src/pkgrepo.py
+++ b/src/pkgrepo.py
@@ -833,7 +833,7 @@ def subcmd_info(conf, args):
                 notfound = set()
 
         def gen_listing():
-                for pfx in found:
+                for pfx in sorted(found):
                         pdata = pub_idx[pfx]
                         pkg_count = pdata.get("package-count", 0)
                         last_update = pdata.get("last-catalog-update", "")
@@ -937,7 +937,7 @@ def subcmd_list(conf, args):
 
         def gen_listing():
                 collect_attrs = out_format.startswith("json")
-                for pub in pub_data:
+                for pub in sorted(pub_data):
                         cat = pub.catalog
                         for f, states, attrs in cat.gen_packages(
                             collect_attrs=collect_attrs, matched=matched,

--- a/src/tests/api/t_manifest.py
+++ b/src/tests/api/t_manifest.py
@@ -23,6 +23,11 @@
 
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
 
+from . import testutils
+if __name__ == "__main__":
+        testutils.setup_environment("../../../proto")
+import pkg5unittest
+
 import unittest
 import tempfile
 import os
@@ -41,11 +46,6 @@ import pkg.misc as misc
 import pkg.portable as portable
 import pkg.facet as facet
 import pkg.variant as variant
-
-# Set the path so that modules above can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
-import pkg5unittest
 
 class TestManifest(pkg5unittest.Pkg5TestCase):
 

--- a/src/tests/api/testutils.py
+++ b/src/tests/api/testutils.py
@@ -27,8 +27,9 @@ import os
 import sys
 
 # Set the path so that modules can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
+path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if path_to_parent not in sys.path:
+        sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 

--- a/src/tests/baseline3.txt
+++ b/src/tests/baseline3.txt
@@ -1,1 +1,0 @@
-cli.t_pkgrepo.py TestPkgRepo.test_10_list|fail

--- a/src/tests/cli/t_pkg_depotd.py
+++ b/src/tests/cli/t_pkg_depotd.py
@@ -827,12 +827,18 @@ class TestDepotOutput(pkg5unittest.SingleDepotTestCase):
                 # Make sure the PKGDEPOT_CONTROLLER is not set in the newenv.
                 newenv = os.environ.copy()
                 newenv.pop("PKGDEPOT_CONTROLLER", None)
-                cmdargs = "/usr/bin/ctrun -o noorphan {0} {1}/usr/lib/pkg.depotd " \
-                    "-p {2} -d {3} --content-root {4}/usr/share/lib/pkg " \
-                    "--readonly </dev/null --log-access={5} " \
-                    "--log-errors={6}".format(sys.executable,
-                    pkg5unittest.g_pkg_path, self.next_free_port, repopath,
-                    pkg5unittest.g_pkg_path, out_path, err_path)
+
+                cmdargs = [
+                    '/usr/bin/ctrun', '-o', 'noorphan',
+                    sys.executable,
+                    '{0}/usr/lib/pkg.depotd'.format(pkg5unittest.g_pkg_path),
+                    '-p', str(self.next_free_port),
+                    '-d', repopath,
+                    '--content-root',
+                        '{0}/usr/share/lib/pkg'.format(pkg5unittest.g_pkg_path),
+                    '--readonly',
+                    '--log-access={0}'.format(out_path),
+                    '--log-errors={0}'.format(err_path)]
 
                 curport = self.next_free_port
                 self.next_free_port += 1
@@ -840,7 +846,7 @@ class TestDepotOutput(pkg5unittest.SingleDepotTestCase):
                 # Start a depot daemon process.
                 try:
                         depot_handle = subprocess.Popen(cmdargs, env=newenv,
-                            shell=True)
+                            stdin=subprocess.DEVNULL)
 
                         self.assertTrue(depot_handle != None, msg="Could not "
                             "start depot")
@@ -888,14 +894,23 @@ class TestDepotOutput(pkg5unittest.SingleDepotTestCase):
                 """Helper function: stop the depot daemon process by sending
                 signal to its handle."""
 
+                if not depot_handle:
+                        return
+
                 # Terminate the depot daemon. If failed, kill it.
                 try:
-                        if depot_handle:
+                        i = 0
+                        while i < 30:
                                 depot_handle.terminate()
+                                if depot_handle.returncode is not None:
+                                        break
+                                time.sleep(0.1)
+                                i += 1
+                        if depot_handle.returncode is None:
+                                depot_handle.kill()
                 except:
                         try:
-                                if depot_handle:
-                                        depot_handle.kill()
+                                depot_handle.kill()
                         except:
                                 pass
 

--- a/src/tests/cli/testutils.py
+++ b/src/tests/cli/testutils.py
@@ -27,8 +27,9 @@ import os
 import sys
 
 # Set the path so that modules can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
+path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if path_to_parent not in sys.path:
+        sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 

--- a/src/tests/testsuite/testutils.py
+++ b/src/tests/testsuite/testutils.py
@@ -27,8 +27,9 @@ import os
 import sys
 
 # Set the path so that modules can be found
-path_to_parent = os.path.join(os.path.dirname(__file__), "..")
-sys.path.insert(0, path_to_parent)
+path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if path_to_parent not in sys.path:
+        sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 


### PR DESCRIPTION
These are cherry-picked changes from @citrus-it and omnios to fix all the test failures.  With these fixes in place 'make test' should match the baseline, and the baseline contains no failures.

Since I'm syncing these with omnios, please leave the commit authors/messages alone so it's easy to see what's been done and what hasn't