### PR TITLE
fix pkglint

### DIFF
--- a/src/pkg/external_deps.txt
+++ b/src/pkg/external_deps.txt
@@ -1,11 +1,20 @@
+    pkg:/SUNWcs
+    pkg:/archiver/gnu-tar
+    pkg:/crypto/ca-certificates
+    pkg:/developer/build/make
+    pkg:/developer/build/onbld
+    pkg:/developer/gnome/gettext
+    pkg:/developer/gnome/gnome-doc-utils
+    pkg:/developer/python/pylint
+    pkg:/developer/versioning/mercurial
     pkg:/library/python/cffi-35
     pkg:/library/python/cherrypy-35
     pkg:/library/python/coverage-35
-    pkg:/library/python/jsonrpclib-35
     pkg:/library/python/cryptography-35
     pkg:/library/python/jsonrpclib-35
     pkg:/library/python/jsonschema-35
     pkg:/library/python/mako-35
+    pkg:/library/python/pep8-35
     pkg:/library/python/ply-35
     pkg:/library/python/portend-35
     pkg:/library/python/prettytable-35
@@ -14,26 +23,24 @@
     pkg:/library/python/pyopenssl-35
     pkg:/library/python/rapidjson-35
     pkg:/library/python/six-35
+    pkg:/locale/en
+    pkg:/network/netcat
     pkg:/package/svr4
     pkg:/runtime/python-35
     pkg:/service/network/dns/mdns
-    pkg:/shell/ksh93
-    pkg:/system/header
-    pkg:/system/library
-    #
-    pkg:/SUNWcs
-    pkg:/archiver/gnu-tar
-    pkg:/developer/build/make
-    pkg:/developer/build/onbld
-    pkg:/package/svr4
-    pkg:/service/network/dns/mdns
     pkg:/shell/bash
+    pkg:/shell/ksh93
+    pkg:/system/bhyve
+    pkg:/system/bhyve/firmware
     pkg:/system/header
     pkg:/system/library
+    pkg:/system/library/bhyve
     pkg:/system/library/dbus
+    pkg:/system/library/gcc-4-runtime
     pkg:/system/library/math
     pkg:/system/library/security/crypto
     pkg:/system/network
+    pkg:/system/qemu/kvm
     pkg:/system/zones
     pkg:/text/gnu-diffutils
     pkg:/text/gnu-gettext
@@ -42,8 +49,4 @@
     pkg:/text/tidy
     pkg:/web/server/apache-24
     pkg:/web/server/apache-24/module/apache-wsgi-35
-    pkg:/web/wget
-    pkg:/SUNWcs
-    pkg:/system/zones
-    pkg:/system/library/gcc-4-runtime
     pkg:/web/wget

--- a/src/pkg/external_deps.txt
+++ b/src/pkg/external_deps.txt
@@ -38,6 +38,7 @@
     pkg:/system/library/dbus
     pkg:/system/library/gcc-4-runtime
     pkg:/system/library/math
+    pkg:/system/library/python/libbe-35
     pkg:/system/library/security/crypto
     pkg:/system/network
     pkg:/system/qemu/kvm

--- a/src/pkg/ips-pkglintrc
+++ b/src/pkg/ips-pkglintrc
@@ -43,7 +43,7 @@ do_pub_checks = True
 
 # List modules or methods which should be excluded from
 # execution during each lint run.
-pkglint.exclude =
+pkglint.exclude = pkg.lint.pkglint_action.PkgActionChecker.arch64
 pkglint.ext.opensolaris = pkg.lint.opensolaris
 
 # The version pattern we use when searching for manifests

--- a/src/pkg/manifests/package:pkg-35.p5m
+++ b/src/pkg/manifests/package:pkg-35.p5m
@@ -23,8 +23,4 @@
 #
 
 set name=pkg.fmri value=pkg:/package/pkg-35@$(PKGVERS)
-set name=pkg.summary \
-    value="Python 3.5 support modules for the Image Packaging System"
-set name=pkg.description \
-    value="Python 3.5 support modules for the Image Packaging System. The Image Packaging System (IPS), or pkg(5), is the software delivery system used on OpenIndiana.  This package contains the core command-line components and pkg.depotd server."
 set name=pkg.obsolete value=true

--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -23,16 +23,18 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
+#
+# Don't worry about the "from x.y.z" six imports since pkgdepend has some issues
+# with the python importer. Instead, we force a dependency on the six package.
+#
 <transform file path=usr/bin/ -> set pkg.depend.bypass-generate .*six.*>
+<transform file path=.*\.py$ -> add pkg.depend.bypass-generate .*six.*>
 set name=pkg.fmri value=pkg:/package/pkg@$(PKGVERS)
 set name=pkg.summary value="Image Packaging System"
 set name=pkg.description \
     value="The Image Packaging System (IPS), or pkg(5), is the software delivery system used on OpenIndiana.  This package contains the core command-line components and pkg.depotd server."
 set name=info.classification \
     value=org.opensolaris.category.2008:System/Packaging
-set name=org.opensolaris.smf.fmri \
-    value=svc:/application/pkg/repositories-setup \
-    value=svc:/application/pkg/repositories-setup:default
 set name=variant.arch value=$(ARCH)
 dir  path=$(PYDIR)
 dir  path=$(PYDIRVP)
@@ -60,92 +62,75 @@ file path=$(PYDIRVP)/pkg/actions/generic.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/group.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/hardlink.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/legacy.py pkg.depend.bypass-generate=.*
-#
-# Don't worry about the "from x.y.z" six imports since pkgdepend has some issues
-# with the python importer. Instead, we force a dependency on the six package.
-#
 file path=$(PYDIRVP)/pkg/actions/license.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/link.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/signature.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/unknown.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/user.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/altroot.py
-file path=$(PYDIRVP)/pkg/api_common.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/api_common.py
 file path=$(PYDIRVP)/pkg/arch.py
 dir  path=$(PYDIRVP)/pkg/bundle
 file path=$(PYDIRVP)/pkg/bundle/DirectoryBundle.py
 file path=$(PYDIRVP)/pkg/bundle/SolarisPackageDatastreamBundle.py
-file path=$(PYDIRVP)/pkg/bundle/SolarisPackageDirBundle.py \
-    pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/bundle/SolarisPackageDirBundle.py
 file path=$(PYDIRVP)/pkg/bundle/TarBundle.py
 file path=$(PYDIRVP)/pkg/bundle/__init__.py
-file path=$(PYDIRVP)/pkg/catalog.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/cfgfiles.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/catalog.py
+file path=$(PYDIRVP)/pkg/cfgfiles.py
 file path=$(PYDIRVP)/pkg/choose.py
 dir  path=$(PYDIRVP)/pkg/client
 file path=$(PYDIRVP)/pkg/client/__init__.py
-file path=$(PYDIRVP)/pkg/client/actuator.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/api.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/api_errors.py pkg.depend.bypass-generate=.*six.*
-#
-# Don't worry about the libbe import; the python code looks for it in case
-# it can't import libbe_py, and is graceful in the face of its absence.
-#
+file path=$(PYDIRVP)/pkg/client/actuator.py
+file path=$(PYDIRVP)/pkg/client/api.py
+file path=$(PYDIRVP)/pkg/client/api_errors.py
+# libbe can't be found by pkgdepend for weird reasons.  dependencies are
+# specified manually below.
 file path=$(PYDIRVP)/pkg/client/bootenv.py pkg.depend.bypass-generate=.*libbe.*
-file path=$(PYDIRVP)/pkg/client/client_api.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/client/debugvalues.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/firmware.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/history.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/image.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/client/imageconfig.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/imageplan.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/client/client_api.py
+file path=$(PYDIRVP)/pkg/client/debugvalues.py
+file path=$(PYDIRVP)/pkg/client/firmware.py
+file path=$(PYDIRVP)/pkg/client/history.py
+file path=$(PYDIRVP)/pkg/client/image.py
+file path=$(PYDIRVP)/pkg/client/imageconfig.py
+file path=$(PYDIRVP)/pkg/client/imageplan.py
 file path=$(PYDIRVP)/pkg/client/imagetypes.py
 file path=$(PYDIRVP)/pkg/client/indexer.py
 dir  path=$(PYDIRVP)/pkg/client/linkedimage
 file path=$(PYDIRVP)/pkg/client/linkedimage/__init__.py
-file path=$(PYDIRVP)/pkg/client/linkedimage/common.py \
-    pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/client/linkedimage/common.py
+# .../linkedimage/... also use relative imports pkgdepend can't see through
 file path=$(PYDIRVP)/pkg/client/linkedimage/system.py \
     pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/client/linkedimage/zone.py \
     pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/client/options.py
-file path=$(PYDIRVP)/pkg/client/pkg_solver.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/client/pkg_solver.py
 file path=$(PYDIRVP)/pkg/client/pkgdefs.py
-file path=$(PYDIRVP)/pkg/client/pkgplan.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/pkgremote.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/plandesc.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/printengine.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/progress.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/publisher.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/client/query_parser.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/sigpolicy.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/client/pkgplan.py
+file path=$(PYDIRVP)/pkg/client/pkgremote.py
+file path=$(PYDIRVP)/pkg/client/plandesc.py
+file path=$(PYDIRVP)/pkg/client/printengine.py
+file path=$(PYDIRVP)/pkg/client/progress.py
+file path=$(PYDIRVP)/pkg/client/publisher.py
+file path=$(PYDIRVP)/pkg/client/query_parser.py
+file path=$(PYDIRVP)/pkg/client/sigpolicy.py
 dir  path=$(PYDIRVP)/pkg/client/transport
 file path=$(PYDIRVP)/pkg/client/transport/__init__.py
-file path=$(PYDIRVP)/pkg/client/transport/engine.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/transport/exception.py \
-    pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/client/transport/engine.py
+file path=$(PYDIRVP)/pkg/client/transport/exception.py
 file path=$(PYDIRVP)/pkg/client/transport/fileobj.py
-file path=$(PYDIRVP)/pkg/client/transport/mdetect.py \
-    pkg.depend.bypass-generate=.*pybonjour.* pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/transport/repo.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/transport/stats.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/client/transport/transport.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/config.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/cpiofile.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/client/transport/mdetect.py
+file path=$(PYDIRVP)/pkg/client/transport/repo.py
+file path=$(PYDIRVP)/pkg/client/transport/stats.py
+file path=$(PYDIRVP)/pkg/client/transport/transport.py
+file path=$(PYDIRVP)/pkg/config.py
+file path=$(PYDIRVP)/pkg/cpiofile.py
 file path=$(PYDIRVP)/pkg/dependency.py
-file path=$(PYDIRVP)/pkg/depotcontroller.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/depotcontroller.py
 file path=$(PYDIRVP)/pkg/digest.py
 file path=$(PYDIRVP)/pkg/elf.cpython-35m.so
-file path=$(PYDIRVP)/pkg/facet.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/facet.py
 dir  path=$(PYDIRVP)/pkg/file_layout
 file path=$(PYDIRVP)/pkg/file_layout/__init__.py
 file path=$(PYDIRVP)/pkg/file_layout/file_manager.py
@@ -153,43 +138,41 @@ file path=$(PYDIRVP)/pkg/file_layout/layout.py
 dir  path=$(PYDIRVP)/pkg/flavor
 file path=$(PYDIRVP)/pkg/flavor/__init__.py
 file path=$(PYDIRVP)/pkg/flavor/base.py
-file path=$(PYDIRVP)/pkg/flavor/depthlimitedmf.py pkg.depend.bypass-generate=.*
+file path=$(PYDIRVP)/pkg/flavor/depthlimitedmf.py
 file path=$(PYDIRVP)/pkg/flavor/elf.py
 file path=$(PYDIRVP)/pkg/flavor/hardlink.py
 file path=$(PYDIRVP)/pkg/flavor/python.py
 file path=$(PYDIRVP)/pkg/flavor/script.py
-file path=$(PYDIRVP)/pkg/flavor/smf_manifest.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/fmri.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/indexer.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/json.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/flavor/smf_manifest.py
+file path=$(PYDIRVP)/pkg/fmri.py
+file path=$(PYDIRVP)/pkg/indexer.py
+file path=$(PYDIRVP)/pkg/json.py
 dir  path=$(PYDIRVP)/pkg/lint
 file path=$(PYDIRVP)/pkg/lint/__init__.py
-file path=$(PYDIRVP)/pkg/lint/base.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/lint/config.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/lint/engine.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/lint/log.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/lint/base.py
+file path=$(PYDIRVP)/pkg/lint/config.py
+file path=$(PYDIRVP)/pkg/lint/engine.py
+file path=$(PYDIRVP)/pkg/lint/log.py
 file path=$(PYDIRVP)/pkg/lint/opensolaris.py
-file path=$(PYDIRVP)/pkg/lint/pkglint_action.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/lint/pkglint_manifest.py \
-    pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/lint/pkglint_action.py
+file path=$(PYDIRVP)/pkg/lint/pkglint_manifest.py
 file path=$(PYDIRVP)/pkg/lockfile.py
-file path=$(PYDIRVP)/pkg/manifest.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/mediator.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/misc.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/mogrify.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/manifest.py
+file path=$(PYDIRVP)/pkg/mediator.py
+file path=$(PYDIRVP)/pkg/misc.py
+file path=$(PYDIRVP)/pkg/mogrify.py
 dir  path=$(PYDIRVP)/pkg/no_site_packages
 file path=$(PYDIRVP)/pkg/no_site_packages/__init__.py
 file path=$(PYDIRVP)/pkg/nrlock.py
-file path=$(PYDIRVP)/pkg/p5i.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/p5p.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/p5s.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/pipeutils.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/p5i.py
+file path=$(PYDIRVP)/pkg/p5p.py
+file path=$(PYDIRVP)/pkg/p5s.py
+file path=$(PYDIRVP)/pkg/pipeutils.py
 file path=$(PYDIRVP)/pkg/pkggzip.py
-file path=$(PYDIRVP)/pkg/pkgsubprocess.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/pkgsubprocess.py
 file path=$(PYDIRVP)/pkg/pkgtarfile.py
 dir  path=$(PYDIRVP)/pkg/portable
+# .../portable/... also uses relative imports pkgdepend can't see through
 file path=$(PYDIRVP)/pkg/portable/__init__.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/portable/os_aix.py pkg.depend.bypass-generate=.*
 # Python on Solaris doesn't deliver the macostools module.
@@ -199,38 +182,34 @@ file path=$(PYDIRVP)/pkg/portable/os_unix.py pkg.depend.bypass-generate=.*
 # Python on Solaris doesn't deliver the win32api module.
 file path=$(PYDIRVP)/pkg/portable/os_windows.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/portable/util.py
-file path=$(PYDIRVP)/pkg/pspawn.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/pspawn.py
 dir  path=$(PYDIRVP)/pkg/publish
 file path=$(PYDIRVP)/pkg/publish/__init__.py
-file path=$(PYDIRVP)/pkg/publish/dependencies.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/publish/transaction.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/query_parser.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/publish/dependencies.py
+file path=$(PYDIRVP)/pkg/publish/transaction.py
+file path=$(PYDIRVP)/pkg/query_parser.py
 file path=$(PYDIRVP)/pkg/search_errors.py
-file path=$(PYDIRVP)/pkg/search_storage.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/search_storage.py
 dir  path=$(PYDIRVP)/pkg/server
 file path=$(PYDIRVP)/pkg/server/__init__.py
-file path=$(PYDIRVP)/pkg/server/api.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/server/api.py
 file path=$(PYDIRVP)/pkg/server/api_errors.py
 file path=$(PYDIRVP)/pkg/server/catalog.py
-file path=$(PYDIRVP)/pkg/server/depot.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/server/face.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/server/feed.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/server/query_parser.py \
-    pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/server/repository.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/server/transaction.py \
-    pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/server/depot.py
+file path=$(PYDIRVP)/pkg/server/face.py
+file path=$(PYDIRVP)/pkg/server/feed.py
+file path=$(PYDIRVP)/pkg/server/query_parser.py
+file path=$(PYDIRVP)/pkg/server/repository.py
+file path=$(PYDIRVP)/pkg/server/transaction.py
 file path=$(PYDIRVP)/pkg/sha512_t.py
-file path=$(PYDIRVP)/pkg/smf.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/smf.py
 file path=$(PYDIRVP)/pkg/solver.cpython-35m.so
-file path=$(PYDIRVP)/pkg/sysattr.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/syscallat.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/sysattr.py
+file path=$(PYDIRVP)/pkg/syscallat.py
 file path=$(PYDIRVP)/pkg/sysvpkg.py
-file path=$(PYDIRVP)/pkg/updatelog.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/variant.py pkg.depend.bypass-generate=.*six.*
-file path=$(PYDIRVP)/pkg/version.py pkg.depend.bypass-generate=.*six.*
+file path=$(PYDIRVP)/pkg/updatelog.py
+file path=$(PYDIRVP)/pkg/variant.py
+file path=$(PYDIRVP)/pkg/version.py
 dir  path=etc
 dir  path=etc/security
 dir  path=etc/security/auth_attr.d
@@ -243,19 +222,15 @@ dir  path=lib
 dir  path=lib/svc
 dir  path=lib/svc/manifest
 dir  path=lib/svc/manifest/application
-file path=lib/svc/manifest/application/pkg/pkg-mdns.xml \
-    pkg.depend.bypass-generate=.*
-file path=lib/svc/manifest/application/pkg/pkg-mirror.xml \
-    pkg.depend.bypass-generate=.*
-file path=lib/svc/manifest/application/pkg/pkg-repositories-setup.xml \
-    pkg.depend.bypass-generate=.*
-file path=lib/svc/manifest/application/pkg/pkg-server.xml \
-    pkg.depend.bypass-generate=.*
+file path=lib/svc/manifest/application/pkg/pkg-mdns.xml
+file path=lib/svc/manifest/application/pkg/pkg-mirror.xml
+file path=lib/svc/manifest/application/pkg/pkg-repositories-setup.xml
+file path=lib/svc/manifest/application/pkg/pkg-server.xml
 dir  path=lib/svc/method
-file path=lib/svc/method/svc-pkg-mdns pkg.depend.bypass-generate=.*
+file path=lib/svc/method/svc-pkg-mdns
 file path=lib/svc/method/svc-pkg-mirror
 file path=lib/svc/method/svc-pkg-repositories-setup
-file path=lib/svc/method/svc-pkg-server pkg.depend.bypass-generate=.*
+file path=lib/svc/method/svc-pkg-server
 dir  path=lib/svc/share
 file path=lib/svc/share/pkg5_include.sh
 dir  path=usr
@@ -263,7 +238,7 @@ dir  path=usr/bin
 file path=usr/bin/pkg
 file path=usr/bin/pkgdepend
 file path=usr/bin/pkgdiff
-file path=usr/bin/pkgfmt pkg.depend.bypass-generate=.*six.*
+file path=usr/bin/pkgfmt
 file path=usr/bin/pkglint
 file path=usr/bin/pkgmerge
 file path=usr/bin/pkgmogrify
@@ -273,7 +248,7 @@ file path=usr/bin/pkgsend
 file path=usr/bin/pkgsign
 file path=usr/bin/pkgsurf
 dir  path=usr/lib
-file path=usr/lib/pkg.depotd mode=0755 pkg.depend.bypass-generate=.*
+file path=usr/lib/pkg.depotd mode=0755 pkg.depend.bypass-generate=.*six.*
 dir  path=usr/share
 dir  path=usr/share/lib
 dir  path=usr/share/lib/pkg
@@ -497,17 +472,5 @@ depend type=group fmri=package/pkg/zones-proxy \
 depend type=require fmri=crypto/ca-certificates
 # CFFI import is done in C code, so it isn't picked up by pkgdepend
 depend type=require fmri=library/python/cffi-35
-depend type=require fmri=library/python/cherrypy-35
-depend type=require fmri=library/python/cryptography-35
-depend type=require fmri=library/python/jsonrpclib-35
-depend type=require fmri=library/python/jsonschema-35
-depend type=require fmri=library/python/mako-35
-depend type=require fmri=library/python/ply-35
-depend type=require fmri=library/python/portend-35
-depend type=require fmri=library/python/prettytable-35
-depend type=require fmri=library/python/pybonjour-35
-depend type=require fmri=library/python/pycurl-35
-depend type=require fmri=library/python/pyopenssl-35
-depend type=require fmri=library/python/rapidjson-35
-depend type=require fmri=library/python/six-35
 depend type=require fmri=locale/en
+depend type=require fmri=system/library/python/libbe-35

--- a/src/pkg/manifests/package:pkg:depot.p5m
+++ b/src/pkg/manifests/package:pkg:depot.p5m
@@ -61,7 +61,6 @@ file path=var/log/pkg/depot/access_log owner=pkg5srv mode=0644 preserve=true
 file path=var/log/pkg/depot/error_log owner=pkg5srv mode=0644 preserve=true
 file path=var/log/pkg/depot/rewrite.log owner=pkg5srv mode=0644 preserve=true
 license cr_Oracle license=cr_Oracle
-depend type=require fmri=package/pkg@$(PKGVERS)
 #
 # The manual dependency on apache results from our calling apachectl from
 # our method script, and can't be detected by pkgdepend.

--- a/src/pkg/manifests/package:pkg:system-repository.p5m
+++ b/src/pkg/manifests/package:pkg:system-repository.p5m
@@ -72,7 +72,6 @@ file path=var/log/pkg/sysrepo/rewrite.log owner=pkg5srv mode=0644 preserve=true
 license cr_Oracle license=cr_Oracle
 # force a dependency on the six package because we bypass dependency check for it
 depend type=require fmri=library/python/six-35
-depend type=require fmri=package/pkg@$(PKGVERS)
 #
 # The manual dependency on apache results from our calling apachectl from
 # our method script, and can't be detected by pkgdepend.

--- a/src/pkg/manifests/system:zones:brand:bhyve.p5m
+++ b/src/pkg/manifests/system:zones:brand:bhyve.p5m
@@ -16,6 +16,8 @@
 set name=pkg.fmri value=pkg:/system/zones/brand/bhyve@$(PKGVERS)
 set name=pkg.summary value="Image Packaging System branded zone - bhyve zones"
 set name=pkg.description value="Support for bhyve branded zones"
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Virtualization
 set name=variant.arch value=$(ARCH)
 dir  path=usr/lib
 dir  path=usr/lib/brand

--- a/src/pkg/manifests/system:zones:brand:ipkg.p5m
+++ b/src/pkg/manifests/system:zones:brand:ipkg.p5m
@@ -60,7 +60,6 @@ file path=usr/lib/brand/ipkg/smf_disable.lst
 file path=usr/lib/brand/ipkg/support mode=0755
 file path=usr/lib/brand/ipkg/system-unconfigure mode=0755
 file path=usr/lib/brand/ipkg/uninstall mode=0755
-legacy pkg=SUNWipkg-brand version=0.0.0
 license cr_Oracle license=cr_Oracle
 depend type=require fmri=package/pkg/zones-proxy
 depend type=require fmri=system/extended-system-utilities pkg.linted=true

--- a/src/pkg/manifests/system:zones:brand:kvm.p5m
+++ b/src/pkg/manifests/system:zones:brand:kvm.p5m
@@ -16,6 +16,8 @@
 set name=pkg.fmri value=pkg:/system/zones/brand/kvm@$(PKGVERS)
 set name=pkg.summary value="Image Packaging System branded zone - kvm zones"
 set name=pkg.description value="Support for kvm branded zones"
+set name=info.classification \
+    value=org.opensolaris.category.2008:System/Virtualization
 set name=variant.arch value=$(ARCH)
 dir  path=usr/lib
 dir  path=usr/lib/brand

--- a/src/util/pkglintrc
+++ b/src/util/pkglintrc
@@ -43,7 +43,7 @@ do_pub_checks = True
 
 # List modules or methods which should be excluded from
 # execution during each lint run.
-pkglint.exclude = pkg.lint.opensolaris
+pkglint.exclude = pkg.lint.opensolaris \
     pkg.lint.pkglint_action.PkgActionChecker.arch64
 
 # The version pattern we use when searching for manifests


### PR DESCRIPTION
This makes 'make package' clean, on top of that prior fixes for 'make check' in src/pkg.

I'd appreciate a good look at 93c2d3b especially, which tries to take all the unnecessary hard bypassing out of the packaging and to let pkgdepend do its work (and make pkglint duplicate dependency checks much easier to reason about).

@citrus-it Do you you know if there are fixes for relative python imports and pkgdepend so we could get the rest fixed too?