### PR TITLE
be consistent and explicit about GCC version and ISA

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,7 @@
 # Copyright (c) 2007, 2016, Oracle and/or its affiliates. All rights reserved.
 #
 
-PYTHON35 = /usr/bin/python3.5
+include Makefile.com
 
 all := TARGET = all
 install := TARGET = install
@@ -47,20 +47,19 @@ PYLINT_VER_CMD = PYTHONPATH= /usr/bin/pkg info pkg:/developer/python/pylint | \
 	/usr/bin/grep Version | \
 	/usr/bin/awk -F: '{print $$2}' | /usr/bin/sed -e 's/ //g'
 
-PEP8 = /usr/bin/pep8
 JOBS = 8
 
 SUBDIRS=brand zoneproxy util/mkcert
 
 all: $(SUBDIRS)
-	$(PYTHON35) setup.py build
+	$(PYTHON) setup.py build
 
 clean: $(SUBDIRS)
-	$(PYTHON35) setup.py clean
+	$(PYTHON) setup.py clean
 	@cd pkg; pwd; make clean
 
 clobber: $(SUBDIRS)
-	$(PYTHON35) setup.py clobber
+	$(PYTHON) setup.py clobber
 	@cd pkg; pwd; make clobber
 
 #
@@ -68,19 +67,19 @@ clobber: $(SUBDIRS)
 # it's the best way to ensure things stay pylint clean.
 #
 install: $(SUBDIRS)
-	CC=$(CC) $(PYTHON35) setup.py install
+	CC=$(CC) $(PYTHON) setup.py install
 
 lint:
-	CC=$(CC) $(PYTHON35) setup.py lint
+	CC=$(CC) $(PYTHON) setup.py lint
 	@cd zoneproxy; pwd; make lint
 
 clint:
-	CC=$(CC) $(PYTHON35) setup.py clint
+	CC=$(CC) $(PYTHON) setup.py clint
 	@cd zoneproxy; pwd; make lint
 
 pylint: install
-	PYLINT_VER=$(PYLINT_VER_CMD:sh) $(PYTHON35) setup.py pylint
-	PYLINT_VER=$(PYLINT_VER_CMD:sh) $(PYTHON35) setup.py pylint_py3k
+	PYLINT_VER=$(PYLINT_VER_CMD:sh) $(PYTHON) setup.py pylint
+	PYLINT_VER=$(PYLINT_VER_CMD:sh) $(PYTHON) setup.py pylint_py3k
 
 pep8:
 	$(PEP8) --statistics --count `cat tests/pep8-whitelist.txt`
@@ -99,6 +98,6 @@ packages: install
 		PYTHONPATH=$$(hg root 2>/dev/null || git rev-parse --show-toplevel)/proto/root_$$(uname -p)/usr/lib/python2.7/vendor-packages
 
 test: install
-	-pfexec $(PYTHON35) tests/run.py -j ${JOBS}
+	-pfexec $(PYTHON) tests/run.py -j ${JOBS}
 
 FRC:

--- a/src/Makefile.com
+++ b/src/Makefile.com
@@ -1,0 +1,21 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+# Copyright 2022, Richard Lowe.
+
+CC = /usr/gcc/7/bin/gcc
+CFLAGS = -m64 -Wall
+CPPFLAGS = -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS
+
+PYTHON_VERSION=3.5
+PEP8 = /usr/bin/pep8
+PYTHON = /usr/bin/python$(PYTHON_VERSION)
+PYTHON_ROOT= usr/lib/python$(PYTHON_VERSION)

--- a/src/brand/Makefile
+++ b/src/brand/Makefile
@@ -23,6 +23,8 @@
 # Copyright (c) 2007, 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
+include ../Makefile.com
+
 MACH:sh = uname -p
 
 INSTALL = /usr/sbin/install
@@ -158,3 +160,4 @@ $(BHYVEBRANDPKG)/createzone: $(BHYVEBRANDPKG)
 $(BHYVEBRANDPKG)/socat: $(BHYVEBRANDPKG)
 	rm -f $@; $(INSTALL) -f $(BHYVEBRANDPKG) -m 0444 kvm/socat
 
+.KEEP_STATE:

--- a/src/brand/support.c
+++ b/src/brand/support.c
@@ -45,7 +45,6 @@
 #include <libzonecfg.h>
 
 static void usage_err(void) __NORETURN;
-static void usage(char *msg, ...) __NORETURN;
 
 static char *bname = NULL;
 
@@ -85,8 +84,6 @@ static int
 do_verify(char *xmlfile)
 {
 	zone_dochandle_t	handle;
-	struct zone_fstab	fstab;
-	struct zone_dstab	dstab;
 
 	if ((handle = zonecfg_init_handle()) == NULL)
 		err(gettext("internal libzonecfg.so.1 error"), 0);

--- a/src/pkg/Makefile
+++ b/src/pkg/Makefile
@@ -22,6 +22,8 @@
 # Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
 #
 
+include ../Makefile.com
+
 PKGVERS_COMPONENT = 0.5.11
 PKGVERS_BUILTON   = 5.11
 UPDATENUM         = 0
@@ -72,12 +74,11 @@ $(PUBLISHALL)MANIFESTS      = $(ALL_MANIFESTS)
 
 # PKGCMDENV needs to specify the interpreter explicitly since the shebang
 # lines include -Es which suppresses the use of non-default environments.
-PYTHON3		  = python3.5
-PYDIR		  = usr/lib/$(PYTHON3)
+PYDIR		  = $(PYTHON_ROOT)
 PYDIRVP		  = $(PYDIR)/vendor-packages
 PKGCMDENV         = \
 	PATH=$(PKGROOT)/usr/bin:/usr/sbin:/usr/bin \
-	PYTHONPATH=$(PKGROOT)/$(PYDIRVP) $(PYTHON3) $(PKGROOT)/usr/bin/
+	PYTHONPATH=$(PKGROOT)/$(PYDIRVP) $(PYTHON) $(PKGROOT)/usr/bin/
 PKG               = $(PKGCMDENV)/pkg
 PKGDEPEND         = $(PKGCMDENV)/pkgdepend
 PKGDIFF           = $(PKGCMDENV)/pkgdiff

--- a/src/pkg/ips-pkglintrc
+++ b/src/pkg/ips-pkglintrc
@@ -40,10 +40,6 @@ do_pub_checks = True
 
 # key = python package implementing those checks
 # pkglint.ext.other = org.foo.barcheck
-
-# List modules or methods which should be excluded from
-# execution during each lint run.
-pkglint.exclude = pkg.lint.pkglint_action.PkgActionChecker.arch64
 pkglint.ext.opensolaris = pkg.lint.opensolaris
 
 # The version pattern we use when searching for manifests

--- a/src/util/pkglintrc
+++ b/src/util/pkglintrc
@@ -41,11 +41,6 @@ do_pub_checks = True
 # key = python package implementing those checks
 # pkglint.ext.other = org.foo.barcheck
 
-# List modules or methods which should be excluded from
-# execution during each lint run.
-pkglint.exclude = pkg.lint.opensolaris \
-    pkg.lint.pkglint_action.PkgActionChecker.arch64
-
 # The version pattern we use when searching for manifests
 # for a given build (only when using the -b flag to pkglint)
 version.pattern = *,5.11-0.

--- a/src/util/qual-simulator/Makefile
+++ b/src/util/qual-simulator/Makefile
@@ -22,8 +22,10 @@
 # Copyright (c) 2009, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 
+include ../../Makefile.com
+
 run: stats.py
-	python3.5 scenario.py
+	$(PYTHON) scenario.py
 
 stats.py:
 	cp ../../modules/client/transport/stats.py .

--- a/src/zoneproxy/Makefile.constants
+++ b/src/zoneproxy/Makefile.constants
@@ -22,18 +22,15 @@
 # Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 
-INSTALL =	/usr/bin/python3.5 ../../setup.py installfile
-CC =		gcc
-LINT =		lint
+include ../../Makefile.com
+
+INSTALL =	$(PYTHON) ../../setup.py installfile
 MKDIR =		mkdir -p
 PROTO_AREA:sh =	echo $(hg root 2>/dev/null || git rev-parse --show-toplevel)/proto/root_$(uname -p)
 ZONES_LIBDIR =	$(PROTO_AREA)/usr/lib/zones
 ZONES_PROG =	$(PROG:%=$(ZONES_LIBDIR)/%)
 
-LINTFLAGS =
-CPPFLAGS =	-D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS -I../zoneproxyd 
-CFLAGS = 	-Wall -O3
-LDFLAGS =	-Bdirect -zdefs
+CPPFLAGS +=	-I../zoneproxyd
 LDLIBS =
 
 CLEANFILES =	$(PROG) $(OBJS)

--- a/src/zoneproxy/zoneproxy-adm/zoneproxy-adm.c
+++ b/src/zoneproxy/zoneproxy-adm/zoneproxy-adm.c
@@ -69,7 +69,7 @@ notify_zoneproxyd(zoneid_t zoneid, boolean_t remove)
 	params.desc_ptr = NULL;
 	params.desc_num = 0;
 	params.rbuf = NULL;
-	params.rsize = NULL;
+	params.rsize = 0;
 	(void) door_call(fd, &params);
 	(void) close(fd);
 }

--- a/src/zoneproxy/zoneproxyd/zoneproxyd.c
+++ b/src/zoneproxy/zoneproxyd/zoneproxyd.c
@@ -1169,7 +1169,7 @@ __zpd_fattach_zone(zoneid_t zid, int door, boolean_t detach_only)
 	if (pid < 0) {
 		(void) ct_tmpl_clear(tmpl_fd);
 		(void) fprintf(stderr,
-		    "Can't fork to add zoneproxy door to zoneid %ld\n", zid);
+		    "Can't fork to add zoneproxy door to zoneid %d\n", zid);
 		drop_privs();
 		return;
 	}
@@ -1203,7 +1203,7 @@ __zpd_fattach_zone(zoneid_t zid, int door, boolean_t detach_only)
 		return;
 	}
 
-	(void) fprintf(stderr, "Unable to attach door to zoneid: %ld\n", zid);
+	(void) fprintf(stderr, "Unable to attach door to zoneid: %d\n", zid);
 
 	if (WEXITSTATUS(stat) == 1)
 		(void) fprintf(stderr, "Cannot enter zone\n");
@@ -1213,7 +1213,7 @@ __zpd_fattach_zone(zoneid_t zid, int door, boolean_t detach_only)
 	else if (WEXITSTATUS(stat) == 3)
 		(void) fprintf(stderr, "Unable to fattach file: %s\n", path);
 
-	(void) fprintf(stderr, "Internal error entering zone: %ld\n", zid);
+	(void) fprintf(stderr, "Internal error entering zone: %d\n", zid);
 	drop_privs();
 }
 
@@ -1237,12 +1237,12 @@ __is_native_zone(zoneid_t zid)
 	const char *name_list[] = { "ipkg", "sn1", "labeled" };
 	uint_t nbrands = sizeof (name_list) / sizeof (const char *);
 	char zonename[ZONENAME_MAX];
-	
+
 	/* global zones have a NULL brand, but can be detected by zid. */
 	if (zid == 0) {
 	        return (B_TRUE);
 	}
-	
+
 	if (getzonenamebyid(zid, zonename, sizeof(zonename))!= -1) {
 		if( zone_get_brand(zonename, brand, sizeof(brand)) == Z_OK) {
 			for (i = 0; i < nbrands; i++) {


### PR DESCRIPTION
This introduces a top-level `Makefile.com` which controls default compiler, flags, python, etc, where it's obvious that we can and should do that.

This should free us from using whatever `cc` or `gcc` we find, and building for whatever ISA that compiler defaults to (we now build 64 bit explicitly regardless).

Because of this,  there's a certain amount of warning cleanup related to both warnings we never enabled in certain subcomponents, and warnings that were previously ISA dependent but now trigger always because 64bit

@citrus-it I'd appreciate you looking as well, because I don't think you did this in OmniOS yet?  I might have missed it.