### PR TITLE
zone/bhyve: add dependency pyyaml-35

### DIFF
--- a/src/pkg/manifests/system:zones:brand:bhyve.p5m
+++ b/src/pkg/manifests/system:zones:brand:bhyve.p5m
@@ -38,3 +38,4 @@ depend type=require fmri=network/netcat
 depend type=require fmri=system/bhyve
 depend type=require fmri=system/bhyve/firmware
 depend type=require fmri=system/library/bhyve
+depend type=require fmri=library/python/pyyaml-35


### PR DESCRIPTION
because the init script uses python-35 and needs yaml