### PR TITLE
Switch pkg to Python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@
 /src/cffi_src/_*
 /src/cffi_src/64
 /src/tests/failures
-/src/tests/failures.3
+/src/tests/failures.3*

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ clobber: $(SUBDIRS) $(PYVERSONS)
 packages: install
 	@cd pkg; pwd; $(MAKE) $(TARGET) check \
 		PATH=$$(hg root 2>/dev/null || git rev-parse --show-toplevel)/proto/root_$$(uname -p)/usr/bin:$$PATH \
-		PYTHONPATH=$$(hg root 2>/dev/null || git rev-parse --show-toplevel)/proto/root_$$(uname -p)/usr/lib/python2.7/vendor-packages
+		PYTHONPATH=$$(hg root 2>/dev/null || git rev-parse --show-toplevel)/proto/root_$$(uname -p)/usr/lib/python3.9/vendor-packages
 
 test: install .WAIT $(PYTESTS)
 

--- a/src/Makefile.com
+++ b/src/Makefile.com
@@ -17,7 +17,7 @@ CPPFLAGS = -D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS
 
 # The version of python used by the scripts, and the 'primary' version in
 # packaging, which is transformed into the others
-PYTHON_VERSION = 3.5
+PYTHON_VERSION = 3.9
 
 # The full set of versions for which modules are delivered
 PYTHON_VERSIONS = 3.5 3.9

--- a/src/brand/bhyve/init
+++ b/src/brand/bhyve/init
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 # {{{ CDDL HEADER
 #

--- a/src/brand/fmri_compare.py
+++ b/src/brand/fmri_compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/brand/kvm/init
+++ b/src/brand/kvm/init
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 # {{{ CDDL HEADER
 #

--- a/src/cffi_src/build_arch.py
+++ b/src/cffi_src/build_arch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/cffi_src/build_pspawn.py
+++ b/src/cffi_src/build_pspawn.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/cffi_src/build_sha512_t.py
+++ b/src/cffi_src/build_sha512_t.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/cffi_src/build_sysattr.py
+++ b/src/cffi_src/build_sysattr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/cffi_src/build_syscallat.py
+++ b/src/cffi_src/build_syscallat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/client.py
+++ b/src/client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/depot-config.py
+++ b/src/depot-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/depot.py
+++ b/src/depot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/modules/__init__.py
+++ b/src/modules/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/__init__.py
+++ b/src/modules/actions/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/attribute.py
+++ b/src/modules/actions/attribute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/depend.py
+++ b/src/modules/actions/depend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/directory.py
+++ b/src/modules/actions/directory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -244,7 +244,7 @@ class DirectoryAction(generic.Action):
                                             path)
                                         raise apx.ActionExecutionError(self,
                                             details=err_txt, error=e,
-                                            fmri=pkgplan.origin_fmri) 
+                                            fmri=pkgplan.origin_fmri)
                         elif e.errno == errno.EBUSY:
                                 # os.path.ismount() is broken for lofs
                                 # filesystems, so give a more generic

--- a/src/modules/actions/driver.py
+++ b/src/modules/actions/driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/file.py
+++ b/src/modules/actions/file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/generic.py
+++ b/src/modules/actions/generic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/group.py
+++ b/src/modules/actions/group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/hardlink.py
+++ b/src/modules/actions/hardlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/legacy.py
+++ b/src/modules/actions/legacy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/license.py
+++ b/src/modules/actions/license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/link.py
+++ b/src/modules/actions/link.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/signature.py
+++ b/src/modules/actions/signature.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/unknown.py
+++ b/src/modules/actions/unknown.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/actions/user.py
+++ b/src/modules/actions/user.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/altroot.py
+++ b/src/modules/altroot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/api_common.py
+++ b/src/modules/api_common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/arch.py
+++ b/src/modules/arch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/DirectoryBundle.py
+++ b/src/modules/bundle/DirectoryBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/SolarisPackageDatastreamBundle.py
+++ b/src/modules/bundle/SolarisPackageDatastreamBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/SolarisPackageDirBundle.py
+++ b/src/modules/bundle/SolarisPackageDirBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/TarBundle.py
+++ b/src/modules/bundle/TarBundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/bundle/__init__.py
+++ b/src/modules/bundle/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/catalog.py
+++ b/src/modules/catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/cfgfiles.py
+++ b/src/modules/cfgfiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/choose.py
+++ b/src/modules/choose.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 Python Software
 # Foundation; All Rights Reserved
 #

--- a/src/modules/client/__init__.py
+++ b/src/modules/client/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/actuator.py
+++ b/src/modules/client/actuator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/debugvalues.py
+++ b/src/modules/client/debugvalues.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/firmware.py
+++ b/src/modules/client/firmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/history.py
+++ b/src/modules/client/history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/imageconfig.py
+++ b/src/modules/client/imageconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/imagetypes.py
+++ b/src/modules/client/imagetypes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/__init__.py
+++ b/src/modules/client/linkedimage/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/common.py
+++ b/src/modules/client/linkedimage/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/system.py
+++ b/src/modules/client/linkedimage/system.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/linkedimage/zone.py
+++ b/src/modules/client/linkedimage/zone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/options.py
+++ b/src/modules/client/options.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkg_solver.py
+++ b/src/modules/client/pkg_solver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkgdefs.py
+++ b/src/modules/client/pkgdefs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkgplan.py
+++ b/src/modules/client/pkgplan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/pkgremote.py
+++ b/src/modules/client/pkgremote.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/plandesc.py
+++ b/src/modules/client/plandesc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/printengine.py
+++ b/src/modules/client/printengine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/progress.py
+++ b/src/modules/client/progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/publisher.py
+++ b/src/modules/client/publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/query_parser.py
+++ b/src/modules/client/query_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/sigpolicy.py
+++ b/src/modules/client/sigpolicy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/__init__.py
+++ b/src/modules/client/transport/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/engine.py
+++ b/src/modules/client/transport/engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/exception.py
+++ b/src/modules/client/transport/exception.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/fileobj.py
+++ b/src/modules/client/transport/fileobj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/mdetect.py
+++ b/src/modules/client/transport/mdetect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/repo.py
+++ b/src/modules/client/transport/repo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/stats.py
+++ b/src/modules/client/transport/stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/client/transport/transport.py
+++ b/src/modules/client/transport/transport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/cpiofile.py
+++ b/src/modules/cpiofile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # Copyright (C) 2002 Lars Gustaebel <lars@gustaebel.de>
 # All rights reserved.

--- a/src/modules/dependency.py
+++ b/src/modules/dependency.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/depotcontroller.py
+++ b/src/modules/depotcontroller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/digest.py
+++ b/src/modules/digest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/facet.py
+++ b/src/modules/facet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/file_layout/__init__.py
+++ b/src/modules/file_layout/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/file_layout/file_manager.py
+++ b/src/modules/file_layout/file_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/file_layout/layout.py
+++ b/src/modules/file_layout/layout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/__init__.py
+++ b/src/modules/flavor/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/base.py
+++ b/src/modules/flavor/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/depthlimitedmf.py
+++ b/src/modules/flavor/depthlimitedmf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # Copyright (c) 2001, 2016, 2003, 2016, 2005, 2016, 2007, 2016, 2009 Python
 # Software Foundation; All Rights Reserved
 #

--- a/src/modules/flavor/elf.py
+++ b/src/modules/flavor/elf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/hardlink.py
+++ b/src/modules/flavor/hardlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/python.py
+++ b/src/modules/flavor/python.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -51,7 +51,7 @@ class PythonModuleMissingPath(base.DependencyAnalysisError):
 
 class PythonMismatchedVersion(base.DependencyAnalysisError):
         """Exception that is raised when a module is installed into a path
-        associated with a known version of python (/usr/lib/python3.5 for
+        associated with a known version of python (/usr/lib/python3.9 for
         example) but has a different version of python specified in its
         #! line (#!/usr/bin/python3.4 for example)."""
 

--- a/src/modules/flavor/script.py
+++ b/src/modules/flavor/script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/flavor/smf_manifest.py
+++ b/src/modules/flavor/smf_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/fmri.py
+++ b/src/modules/fmri.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/indexer.py
+++ b/src/modules/indexer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/json.py
+++ b/src/modules/json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # {{{ CDDL HEADER
 #

--- a/src/modules/lint/__init__.py
+++ b/src/modules/lint/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/base.py
+++ b/src/modules/lint/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/config.py
+++ b/src/modules/lint/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 #
 # CDDL HEADER START

--- a/src/modules/lint/engine.py
+++ b/src/modules/lint/engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/log.py
+++ b/src/modules/lint/log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/opensolaris.py
+++ b/src/modules/lint/opensolaris.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/pkglint_action.py
+++ b/src/modules/lint/pkglint_action.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lint/pkglint_manifest.py
+++ b/src/modules/lint/pkglint_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/lockfile.py
+++ b/src/modules/lockfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/manifest.py
+++ b/src/modules/manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/mediator.py
+++ b/src/modules/mediator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/mogrify.py
+++ b/src/modules/mogrify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/nrlock.py
+++ b/src/modules/nrlock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/p5i.py
+++ b/src/modules/p5i.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/p5p.py
+++ b/src/modules/p5p.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/p5s.py
+++ b/src/modules/p5s.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pipeutils.py
+++ b/src/modules/pipeutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pkggzip.py
+++ b/src/modules/pkggzip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pkgsubprocess.py
+++ b/src/modules/pkgsubprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pkgtarfile.py
+++ b/src/modules/pkgtarfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/__init__.py
+++ b/src/modules/portable/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_aix.py
+++ b/src/modules/portable/os_aix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_darwin.py
+++ b/src/modules/portable/os_darwin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_sunos.py
+++ b/src/modules/portable/os_sunos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_unix.py
+++ b/src/modules/portable/os_unix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/os_windows.py
+++ b/src/modules/portable/os_windows.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/portable/util.py
+++ b/src/modules/portable/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/pspawn.py
+++ b/src/modules/pspawn.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/publish/__init__.py
+++ b/src/modules/publish/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/publish/dependencies.py
+++ b/src/modules/publish/dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/publish/transaction.py
+++ b/src/modules/publish/transaction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/query_parser.py
+++ b/src/modules/query_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/search_errors.py
+++ b/src/modules/search_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/search_storage.py
+++ b/src/modules/search_storage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/__init__.py
+++ b/src/modules/server/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/api.py
+++ b/src/modules/server/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/api_errors.py
+++ b/src/modules/server/api_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/catalog.py
+++ b/src/modules/server/catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/depot.py
+++ b/src/modules/server/depot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/face.py
+++ b/src/modules/server/face.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/feed.py
+++ b/src/modules/server/feed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/query_parser.py
+++ b/src/modules/server/query_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/repository.py
+++ b/src/modules/server/repository.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/server/transaction.py
+++ b/src/modules/server/transaction.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/sha512_t.py
+++ b/src/modules/sha512_t.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/smf.py
+++ b/src/modules/smf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/sysattr.py
+++ b/src/modules/sysattr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/syscallat.py
+++ b/src/modules/syscallat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/sysvpkg.py
+++ b/src/modules/sysvpkg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/updatelog.py
+++ b/src/modules/updatelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/variant.py
+++ b/src/modules/variant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/modules/version.py
+++ b/src/modules/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/pkg/Makefile
+++ b/src/pkg/Makefile
@@ -257,7 +257,7 @@ lint: repository-metadata $(PDIR)
 # to pkgsend generate.
 TARGETS.cmd       = \
 	$(PKGMOGRIFY) -O /dev/null transforms/find-links $(MOGRIFESTS) | \
-		python -c 'import os, sys; print(" ".join(("--target " + os.path.normpath(os.path.join(os.path.dirname(p), t)) for p, t in (l.strip().split() for l in sys.stdin.readlines()))))'
+		$(PYTHON) -c 'import os, sys; print(" ".join(("--target " + os.path.normpath(os.path.join(os.path.dirname(p), t)) for p, t in (l.strip().split() for l in sys.stdin.readlines()))))'
 
 # Create a pseudo-manifest of the proto area
 $(PDIR)/protomanifest: FRC transforms/compare-strip $(PDIR)

--- a/src/pkg/Makefile
+++ b/src/pkg/Makefile
@@ -120,7 +120,7 @@ PKGMOG_DEFINES    = $(PKGMOG_DEFVALS:%=-D %)
 PKGMOG_DEFINES    += $(ARCH_DEFINES:%=-D %)
 
 all: $(MOGRIFESTS)
-install: lint
+install: repository-metadata $(PDIR) lint
 
 clean:
 	rm -rf $(PDIR)

--- a/src/pkg/external_deps.txt
+++ b/src/pkg/external_deps.txt
@@ -36,6 +36,8 @@
     pkg:/library/python/pycurl-39
     pkg:/library/python/pyopenssl-35
     pkg:/library/python/pyopenssl-39
+    pkg:/library/python/pyyaml-35
+    pkg:/library/python/pyyaml-39
     pkg:/library/python/rapidjson-35
     pkg:/library/python/rapidjson-39
     pkg:/library/python/six-35

--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -39,20 +39,20 @@ set name=variant.arch value=$(ARCH)
 dir  path=$(PYDIR)
 dir  path=$(PYDIRVP)
 dir  path=$(PYDIRVP)/pkg
-file path=$(PYDIRVP)/pkg-0.1-py3.5.egg-info
+file path=$(PYDIRVP)/pkg-0.1-py3.9.egg-info
 file path=$(PYDIRVP)/pkg/__init__.py
-file path=$(PYDIRVP)/pkg/_arch.cpython-35m.so
-file path=$(PYDIRVP)/pkg/_pspawn.cpython-35m.so
-file path=$(PYDIRVP)/pkg/_sha512_t.cpython-35m.so
-file path=$(PYDIRVP)/pkg/_sysattr.cpython-35m.so
-file path=$(PYDIRVP)/pkg/_syscallat.cpython-35m.so
-file path=$(PYDIRVP)/pkg/_varcet.cpython-35m.so
+file path=$(PYDIRVP)/pkg/_arch.cpython-39.so
+file path=$(PYDIRVP)/pkg/_pspawn.cpython-39.so
+file path=$(PYDIRVP)/pkg/_sha512_t.cpython-39.so
+file path=$(PYDIRVP)/pkg/_sysattr.cpython-39.so
+file path=$(PYDIRVP)/pkg/_syscallat.cpython-39.so
+file path=$(PYDIRVP)/pkg/_varcet.cpython-39.so
 dir  path=$(PYDIRVP)/pkg/actions
 # pkgdepend doesn't understand the relative import syntax "from .x import y",
 # so we have to bypass generating dependencies on those files.
 file path=$(PYDIRVP)/pkg/actions/__init__.py pkg.depend.bypass-generate=.*
-file path=$(PYDIRVP)/pkg/actions/_actions.cpython-35m.so
-file path=$(PYDIRVP)/pkg/actions/_common.cpython-35m.so
+file path=$(PYDIRVP)/pkg/actions/_actions.cpython-39.so
+file path=$(PYDIRVP)/pkg/actions/_common.cpython-39.so
 file path=$(PYDIRVP)/pkg/actions/attribute.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/depend.py pkg.depend.bypass-generate=.*
 file path=$(PYDIRVP)/pkg/actions/directory.py pkg.depend.bypass-generate=.*
@@ -129,7 +129,7 @@ file path=$(PYDIRVP)/pkg/cpiofile.py
 file path=$(PYDIRVP)/pkg/dependency.py
 file path=$(PYDIRVP)/pkg/depotcontroller.py
 file path=$(PYDIRVP)/pkg/digest.py
-file path=$(PYDIRVP)/pkg/elf.cpython-35m.so
+file path=$(PYDIRVP)/pkg/elf.cpython-39.so
 file path=$(PYDIRVP)/pkg/facet.py
 dir  path=$(PYDIRVP)/pkg/file_layout
 file path=$(PYDIRVP)/pkg/file_layout/__init__.py
@@ -203,7 +203,7 @@ file path=$(PYDIRVP)/pkg/server/repository.py
 file path=$(PYDIRVP)/pkg/server/transaction.py
 file path=$(PYDIRVP)/pkg/sha512_t.py
 file path=$(PYDIRVP)/pkg/smf.py
-file path=$(PYDIRVP)/pkg/solver.cpython-35m.so
+file path=$(PYDIRVP)/pkg/solver.cpython-39.so
 file path=$(PYDIRVP)/pkg/sysattr.py
 file path=$(PYDIRVP)/pkg/syscallat.py
 file path=$(PYDIRVP)/pkg/sysvpkg.py

--- a/src/pkg/manifests/system:zones:brand:bhyve.p5m
+++ b/src/pkg/manifests/system:zones:brand:bhyve.p5m
@@ -35,6 +35,7 @@ file path=usr/lib/brand/bhyve/uninstall mode=0755
 file path=usr/lib/brand/bhyve/util.ksh mode=0644
 file path=usr/lib/brand/bhyve/vars.ksh mode=0644
 depend type=require fmri=library/python/pyyaml-35
+depend type=require fmri=library/python/pyyaml-39
 depend type=require fmri=network/netcat
 depend type=require fmri=system/bhyve
 depend type=require fmri=system/bhyve/firmware

--- a/src/pkg/transforms/compare-strip
+++ b/src/pkg/transforms/compare-strip
@@ -30,7 +30,7 @@
 # the wrong /usr/lib/pythonXY in the proto area, remove them.
 #
 # We always check PYDIRVP (the default python) and hard-code the "other" to drop.
-<transform file path=$(PYDIRVP)/.*/.*cpython-39.pyc -> drop>
+<transform file path=$(PYDIRVP)/.*/.*cpython-35.pyc -> drop>
 
 # Reduce manifests to the bare minimum; we don't really care about anything
 # but path.

--- a/src/pkg/transforms/defaults
+++ b/src/pkg/transforms/defaults
@@ -107,12 +107,4 @@
 set name=org.opensolaris.consolidation value=ips
 set name=variant.opensolaris.zone value=global value=nonglobal
 
-# Generate a python 2.7 dir/file action for each python 2.6 dir/file action
-# it ran across.
-<transform file dir link hardlink path=(.*)python2.6(.*) -> emit %(action.name) path=%<1>python2.7%<2>>
-# Do the version substitution on the .egg-info file.
-<transform file path=.*python2.7.*py2.6.egg-info -> edit path py2.6 py2.7>
-# Avoid generating dependencies against any 2.7 file.
-<transform file path=.*python2.7 -> default pkg.depend.bypass-generate .*>
-
 # vim: ft=pkg5manifest

--- a/src/pkg/transforms/py39
+++ b/src/pkg/transforms/py39
@@ -20,7 +20,8 @@
   %(pkg.depend.bypass-generate;notfound='notfound';prefix='pkg.depend.bypass-generate=')>
 
 <transform path=TBD -> delete pkg.depend.bypass-generate notfound>
-<transform path=TBD -> edit path 35m? 39>
-<transform path=TBD -> edit path 3.5 3.9>
+<transform path=TBD -> edit path -39\.so -35m\.so>
+<transform path=TBD -> edit path -39\.pyc -35\.pyc>
+<transform path=TBD -> edit path 3.9 3.5>
+<transform path=TBD -> edit path py3.9 py3.5>
 <transform path=TBD -> edit path TBD ''>
-

--- a/src/pkgdep.py
+++ b/src/pkgdep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/pkgrepo.py
+++ b/src/pkgrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/publish.py
+++ b/src/publish.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/pull.py
+++ b/src/pull.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/scripts/pkg.bat
+++ b/src/scripts/pkg.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=client.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.5\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkg.depotd.bat
+++ b/src/scripts/pkg.depotd.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=depot.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.5\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkg.depotd.sh
+++ b/src/scripts/pkg.depotd.sh
@@ -55,12 +55,12 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib:/usr/sfw/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.5/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_REPO=${my_base}/var/pkg/repo
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_REPO PKG_HOME
-if [ -x ${my_base}/python/bin/python3.5 ] ; then
-  PYEXE=${my_base}/python/bin/python3.5
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/scripts/pkg.sh
+++ b/src/scripts/pkg.sh
@@ -55,11 +55,11 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.5/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_HOME
-if [ -x ${my_base}/python/bin/python3.5 ] ; then
-  PYEXE=${my_base}/python/bin/python3.5
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/scripts/pkgrecv.bat
+++ b/src/scripts/pkgrecv.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=pull.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.5\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkgrecv.sh
+++ b/src/scripts/pkgrecv.sh
@@ -55,11 +55,11 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.5/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_HOME
-if [ -x ${my_base}/python/bin/python3.5 ] ; then
-  PYEXE=${my_base}/python/bin/python3.5
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/scripts/pkgsend.bat
+++ b/src/scripts/pkgsend.bat
@@ -26,7 +26,7 @@ setlocal
 set CMDSCRIPT=publish.py
 set MY_HOME=%~dp0
 set MY_IPS_BASE=%MY_HOME%\..\..
-set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.5\vendor-packages
+set PYTHONPATH=%PYTHONPATH%;%MY_IPS_BASE%\usr\lib\python3.9\vendor-packages
 set MY_BASE=%MY_HOME%\..\..\..
 set PATH=%MY_BASE%\python;%PATH%
 set PYTHONUNBUFFERED=yes

--- a/src/scripts/pkgsend.sh
+++ b/src/scripts/pkgsend.sh
@@ -55,11 +55,11 @@ my_base=`cd ${my_home}/../../..; pwd`
 my_ips_base=`cd ${my_home}/../..; pwd`
 LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${my_ips_base}/usr/lib
 PYTHONHOME=${my_base}/python
-PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.5/vendor-packages
+PYTHONPATH=${PYTHONPATH}:${my_ips_base}/usr/lib/python3.9/vendor-packages
 PKG_HOME=${my_ips_base}/usr
 export LD_LIBRARY_PATH PYTHONHOME PYTHONPATH PKG_HOME
-if [ -x ${my_base}/python/bin/python3.5 ] ; then
-  PYEXE=${my_base}/python/bin/python3.5
+if [ -x ${my_base}/python/bin/python3.9 ] ; then
+  PYEXE=${my_base}/python/bin/python3.9
 else
   PYEXE=`which python`
   unset PYTHONHOME

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/sign.py
+++ b/src/sign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/sysrepo.py
+++ b/src/sysrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/__init__.py
+++ b/src/tests/api/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_action.py
+++ b/src/tests/api/t_action.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_altroot.py
+++ b/src/tests/api/t_altroot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_api.py
+++ b/src/tests/api/t_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_api_info.py
+++ b/src/tests/api/t_api_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_api_list.py
+++ b/src/tests/api/t_api_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_api_refresh.py
+++ b/src/tests/api/t_api_refresh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_api_search.py
+++ b/src/tests/api/t_api_search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -56,7 +56,7 @@ class TestApiSearchBasics(pkg5unittest.SingleDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.5/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add link path=/bin/exlink target=/bin/example_path mediator=example mediator-version=7.0 mediator-implementation=unladen-swallow
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
@@ -185,7 +185,7 @@ close
         ])
 
         res_remote_openssl = set([
-            ("pkg:/example_pkg@1.0-0", "basename", "dir group=bin mode=0755 owner=root path=usr/lib/python3.5/vendor-packages/OpenSSL")
+            ("pkg:/example_pkg@1.0-0", "basename", "dir group=bin mode=0755 owner=root path=usr/lib/python3.9/vendor-packages/OpenSSL")
         ])
 
         res_remote_bug_id = set([

--- a/src/tests/api/t_async_rpc.py
+++ b/src/tests/api/t_async_rpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_bootenv.py
+++ b/src/tests/api/t_bootenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_catalog.py
+++ b/src/tests/api/t_catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/api/t_client.py
+++ b/src/tests/api/t_client.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/api/t_config.py
+++ b/src/tests/api/t_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/api/t_dependencies.py
+++ b/src/tests/api/t_dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -70,7 +70,7 @@ class TestDependencyAnalyzer(pkg5unittest.Pkg5TestCase):
             "script_path": "lib/svc/method/svc-pkg-depot",
             "syslog_path": "var/log/syslog",
             "py_mod_path": "usr/lib/python2.7/vendor-packages/cProfile.py",
-            "py_mod_path35": "usr/lib/python3.5/vendor-packages/cProfile.py"
+            "py_mod_path39": "usr/lib/python3.9/vendor-packages/cProfile.py"
         }
 
         smf_paths = {
@@ -138,7 +138,7 @@ file NOHASH group=bin mode=0755 owner=root path={pkg_path}
 
         python_mod_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={py_mod_path}
-file NOHASH group=bin mode=0755 owner=root path={py_mod_path35}
+file NOHASH group=bin mode=0755 owner=root path={py_mod_path39}
 """.format(**paths)
 
         relative_ext_depender_manf = """ \

--- a/src/tests/api/t_elf.py
+++ b/src/tests/api/t_elf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_file_manager.py
+++ b/src/tests/api/t_file_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_fmri.py
+++ b/src/tests/api/t_fmri.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_history.py
+++ b/src/tests/api/t_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_imageconfig.py
+++ b/src/tests/api/t_imageconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_indexer.py
+++ b/src/tests/api/t_indexer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_linked_image.py
+++ b/src/tests/api/t_linked_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_manifest.py
+++ b/src/tests/api/t_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/api/t_misc.py
+++ b/src/tests/api/t_misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -159,7 +159,7 @@ except MemoryError:
                 with open(tmpfile, 'w') as f:
                         f.write(waste_mem_py)
 
-                res = int(subprocess.check_output(['python3.5', tmpfile]))
+                res = int(subprocess.check_output(['python3.9', tmpfile]))
                 # convert from kB to bytes
                 res *= 1024
 
@@ -173,7 +173,7 @@ except MemoryError:
 
                 # test if env var works
                 os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = str(mem_cap * 2)
-                res = int(subprocess.check_output(['python3.5', tmpfile]))
+                res = int(subprocess.check_output(['python3.9', tmpfile]))
                 res *= 1024
 
                 self.debug("mem_cap:   " + str(mem_cap * 2))
@@ -190,7 +190,7 @@ except MemoryError:
 
                 # test if invalid env var is handled correctly
                 os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = "octopus"
-                res = int(subprocess.check_output(['python3.5', tmpfile]))
+                res = int(subprocess.check_output(['python3.9', tmpfile]))
                 res *= 1024
 
                 self.debug("mem_cap:   " + str(mem_cap))

--- a/src/tests/api/t_p5i.py
+++ b/src/tests/api/t_p5i.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_p5p.py
+++ b/src/tests/api/t_p5p.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_pkg_api_fix.py
+++ b/src/tests/api/t_pkg_api_fix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_pkg_api_hydrate.py
+++ b/src/tests/api/t_pkg_api_hydrate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_pkg_api_install.py
+++ b/src/tests/api/t_pkg_api_install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_pkg_api_revert.py
+++ b/src/tests/api/t_pkg_api_revert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_pkglint.py
+++ b/src/tests/api/t_pkglint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_pkgtarfile.py
+++ b/src/tests/api/t_pkgtarfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_plat.py
+++ b/src/tests/api/t_plat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_printengine.py
+++ b/src/tests/api/t_printengine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_progress.py
+++ b/src/tests/api/t_progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_publisher.py
+++ b/src/tests/api/t_publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_sha512_t.py
+++ b/src/tests/api/t_sha512_t.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 # 
 # CDDL HEADER START

--- a/src/tests/api/t_smf.py
+++ b/src/tests/api/t_smf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_solver.py
+++ b/src/tests/api/t_solver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_sysattr.py
+++ b/src/tests/api/t_sysattr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_unix_usergrp.py
+++ b/src/tests/api/t_unix_usergrp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_variant.py
+++ b/src/tests/api/t_variant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/t_version.py
+++ b/src/tests/api/t_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/api/testutils.py
+++ b/src/tests/api/testutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/baseline.py
+++ b/src/tests/baseline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/certgenerator.py
+++ b/src/tests/certgenerator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/__init__.py
+++ b/src/tests/cli/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_actuators.py
+++ b/src/tests/cli/t_actuators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_change_facet.py
+++ b/src/tests/cli/t_change_facet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_change_variant.py
+++ b/src/tests/cli/t_change_variant.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_client_api.py
+++ b/src/tests/cli/t_client_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_colliding_links.py
+++ b/src/tests/cli/t_colliding_links.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_depot_config.py
+++ b/src/tests/cli/t_depot_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 #
 # CDDL HEADER START

--- a/src/tests/cli/t_fix.py
+++ b/src/tests/cli/t_fix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_https.py
+++ b/src/tests/cli/t_https.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_lock.py
+++ b/src/tests/cli/t_lock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_origin_fw.py
+++ b/src/tests/cli/t_origin_fw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_R_option.py
+++ b/src/tests/cli/t_pkg_R_option.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_avoid.py
+++ b/src/tests/cli/t_pkg_avoid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_composite.py
+++ b/src/tests/cli/t_pkg_composite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_contents.py
+++ b/src/tests/cli/t_pkg_contents.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_depotd.py
+++ b/src/tests/cli/t_pkg_depotd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_errors.py
+++ b/src/tests/cli/t_pkg_errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/cli/t_pkg_freeze.py
+++ b/src/tests/cli/t_pkg_freeze.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_help.py
+++ b/src/tests/cli/t_pkg_help.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_history.py
+++ b/src/tests/cli/t_pkg_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_hydrate.py
+++ b/src/tests/cli/t_pkg_hydrate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_image_create.py
+++ b/src/tests/cli/t_pkg_image_create.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_image_update.py
+++ b/src/tests/cli/t_pkg_image_update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_info.py
+++ b/src/tests/cli/t_pkg_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_initinstall.py
+++ b/src/tests/cli/t_pkg_initinstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/cli/t_pkg_install.py
+++ b/src/tests/cli/t_pkg_install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/cli/t_pkg_intent.py
+++ b/src/tests/cli/t_pkg_intent.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_linked.py
+++ b/src/tests/cli/t_pkg_linked.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/cli/t_pkg_list.py
+++ b/src/tests/cli/t_pkg_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_mediated.py
+++ b/src/tests/cli/t_pkg_mediated.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -198,8 +198,8 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             close
             open pkg://test/runtime/python-unladen-swallow-35@3.5.0
             add set name=pkg.summary value="Example python versioned implementation package"
-            add file tmp/foopyus path=/usr/bin/python3.5-unladen-swallow owner=root group=bin mode=0555
-            add link path=/usr/bin/python target=python3.5-unladen-swallow mediator=python mediator-version=3.5 mediator-implementation=unladen-swallow@3.5
+            add file tmp/foopyus path=/usr/bin/python3.9-unladen-swallow owner=root group=bin mode=0555
+            add link path=/usr/bin/python target=python3.9-unladen-swallow mediator=python mediator-version=3.5 mediator-implementation=unladen-swallow@3.5
             close """
 
         pkg_multi_python = """
@@ -951,7 +951,7 @@ python\tlocal\t2.7\tlocal\t\t
                 self.pkg("verify")
                 self.pkg("set-mediator -vvv "
                     "-V '' -I unladen-swallow@3.5 python")
-                check_target(gen_python_links(), "python3.5-unladen-swallow")
+                check_target(gen_python_links(), "python3.9-unladen-swallow")
                 self.__assert_mediation_matches("""\
 python\tsystem\t3.5\tlocal\tunladen-swallow@3.5\t
 """)
@@ -960,7 +960,7 @@ python\tsystem\t3.5\tlocal\tunladen-swallow@3.5\t
                 # Set mediation to unladen-swallow and verify
                 # unladen-swallow@3.5 remains selected.
                 self.pkg("set-mediator -vvv -I unladen-swallow python")
-                check_target(gen_python_links(), "python3.5-unladen-swallow")
+                check_target(gen_python_links(), "python3.9-unladen-swallow")
                 self.__assert_mediation_matches("""\
 python\tsystem\t3.5\tlocal\tunladen-swallow\t3.5
 """)

--- a/src/tests/cli/t_pkg_modified.py
+++ b/src/tests/cli/t_pkg_modified.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_nasty.py
+++ b/src/tests/cli/t_pkg_nasty.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_property.py
+++ b/src/tests/cli/t_pkg_property.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_publisher.py
+++ b/src/tests/cli/t_pkg_publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_rebuild_index.py
+++ b/src/tests/cli/t_pkg_rebuild_index.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_refresh.py
+++ b/src/tests/cli/t_pkg_refresh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_revert.py
+++ b/src/tests/cli/t_pkg_revert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_search.py
+++ b/src/tests/cli/t_pkg_search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -58,7 +58,7 @@ class TestPkgSearchBasics(pkg5unittest.SingleDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.5/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
             add set name=com.sun.service.random_test value=42 value=79
@@ -158,7 +158,7 @@ close
 
         res_remote_openssl = set([
             headers,
-            "basename   dir       usr/lib/python3.5/vendor-packages/OpenSSL pkg:/example_pkg@1.0-0\n"
+            "basename   dir       usr/lib/python3.9/vendor-packages/OpenSSL pkg:/example_pkg@1.0-0\n"
         ])
 
         res_remote_bug_id = set([

--- a/src/tests/cli/t_pkg_sysrepo.py
+++ b/src/tests/cli/t_pkg_sysrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_temp_sources.py
+++ b/src/tests/cli/t_pkg_temp_sources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_terminal.py
+++ b/src/tests/cli/t_pkg_terminal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_uninstall.py
+++ b/src/tests/cli/t_pkg_uninstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_varcet.py
+++ b/src/tests/cli/t_pkg_varcet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_verify.py
+++ b/src/tests/cli/t_pkg_verify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkg_version.py
+++ b/src/tests/cli/t_pkg_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgdep.py
+++ b/src/tests/cli/t_pkgdep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgdep_resolve.py
+++ b/src/tests/cli/t_pkgdep_resolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgdiff.py
+++ b/src/tests/cli/t_pkgdiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgfmt.py
+++ b/src/tests/cli/t_pkgfmt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkglint.py
+++ b/src/tests/cli/t_pkglint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgmerge.py
+++ b/src/tests/cli/t_pkgmerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgmogrify.py
+++ b/src/tests/cli/t_pkgmogrify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgrecv.py
+++ b/src/tests/cli/t_pkgrecv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgrepo.py
+++ b/src/tests/cli/t_pkgrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgsend.py
+++ b/src/tests/cli/t_pkgsend.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_pkgsign.py
+++ b/src/tests/cli/t_pkgsign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #
@@ -80,7 +80,7 @@ class TestPkgSign(pkg5unittest.SingleDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.5/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
             add set name=com.sun.service.random_test value=42 value=79
@@ -2869,7 +2869,7 @@ class TestPkgSignMultiDepot(pkg5unittest.ManyDepotTestCase):
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
-            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.5/vendor-packages/OpenSSL
+            add dir mode=0755 owner=root group=bin path=/usr/lib/python3.9/vendor-packages/OpenSSL
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path
             add set name=com.sun.service.incorporated_changes value="6556919 6627937"
             add set name=com.sun.service.random_test value=42 value=79

--- a/src/tests/cli/t_pkgsurf.py
+++ b/src/tests/cli/t_pkgsurf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_publish_api.py
+++ b/src/tests/cli/t_publish_api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_sysrepo.py
+++ b/src/tests/cli/t_sysrepo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 # -*- coding: utf-8 -*-
 #
 # CDDL HEADER START

--- a/src/tests/cli/t_util_merge.py
+++ b/src/tests/cli/t_util_merge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_util_update_file_layout.py
+++ b/src/tests/cli/t_util_update_file_layout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/t_variants.py
+++ b/src/tests/cli/t_variants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/cli/testutils.py
+++ b/src/tests/cli/testutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/interactive/runprintengine.py
+++ b/src/tests/interactive/runprintengine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/interactive/runprogress.py
+++ b/src/tests/interactive/runprogress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/multiplatform.py
+++ b/src/tests/multiplatform.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/perf/actionbench.py
+++ b/src/tests/perf/actionbench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/perf/fmribench.py
+++ b/src/tests/perf/fmribench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/perf/manbench.py
+++ b/src/tests/perf/manbench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/perf/membench.py
+++ b/src/tests/perf/membench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/pkg5testenv.py
+++ b/src/tests/pkg5testenv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 
 # CDDL HEADER START
 #

--- a/src/tests/ro_data/signing_certs/generate_certs.py
+++ b/src/tests/ro_data/signing_certs/generate_certs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/testsuite/__init__.py
+++ b/src/tests/testsuite/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/testsuite/t_setup_teardown.py
+++ b/src/tests/testsuite/t_setup_teardown.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/tests/testsuite/testutils.py
+++ b/src/tests/testsuite/testutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/apache2/depot/depot_index.py
+++ b/src/util/apache2/depot/depot_index.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/apache2/sysrepo/sysrepo_p5p.py
+++ b/src/util/apache2/sysrepo/sysrepo_p5p.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an2_ip.py
+++ b/src/util/log-scripts/an2_ip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an2_ip_active.py
+++ b/src/util/log-scripts/an2_ip_active.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_catalog.py
+++ b/src/util/log-scripts/an_catalog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_filelist.py
+++ b/src/util/log-scripts/an_filelist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_first_timestamp.py
+++ b/src/util/log-scripts/an_first_timestamp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_ip_active.py
+++ b/src/util/log-scripts/an_ip_active.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_manifest.py
+++ b/src/util/log-scripts/an_manifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_report.py
+++ b/src/util/log-scripts/an_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/an_search.py
+++ b/src/util/log-scripts/an_search.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/config.py
+++ b/src/util/log-scripts/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/in_footer.py
+++ b/src/util/log-scripts/in_footer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/in_header.py
+++ b/src/util/log-scripts/in_header.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/log-scripts/translate.py
+++ b/src/util/log-scripts/translate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgdiff.py
+++ b/src/util/publish/pkgdiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgfmt.py
+++ b/src/util/publish/pkgfmt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkglint.py
+++ b/src/util/publish/pkglint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgmerge.py
+++ b/src/util/publish/pkgmerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgmogrify.py
+++ b/src/util/publish/pkgmogrify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/pkgsurf.py
+++ b/src/util/publish/pkgsurf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5 -Es
+#!/usr/bin/python3.9 -Es
 #
 # CDDL HEADER START
 #

--- a/src/util/publish/update_file_layout.py
+++ b/src/util/publish/update_file_layout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/qual-simulator/depot.py
+++ b/src/util/qual-simulator/depot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #

--- a/src/util/qual-simulator/scenario.py
+++ b/src/util/qual-simulator/scenario.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.5
+#!/usr/bin/python3.9
 #
 # CDDL HEADER START
 #


### PR DESCRIPTION
This switches pkg to use python 3.9 primarily (that is, the scripts etc. use the 3.9 interpreter).
It still delivers 3.5 libraries to ease compatibility (if you have, for eg, illumos tools that need to work with 3.5 for a bit).

You _do_ however, need to have an illumos which builds 3.9 bits.

I need to send a heads-up to developer@illumos and OI when this integrates, a draft is:

```
Subject: HEADS-UP: pkg update to Python 3.9 needs illumos environment changes

Due to the update to pkg to use Python 3.9 in OpenIndiana, your illumos builds _must_ produce a libbe-39 package.
This means your build must be set up such that PYTHON3_VERSION or PYTHON3b_VERSION are 3.9:

export PYTHON3b_VERSION=3.9
export PYTHON3b_SUFFIX=
export PYTHON3b_PKGVERS=-39

A future change to illumos will make this the default PYTHON3_VERSION.
```
It makes most sense for whoever merges this PR to send the heads-up, since that's when it needs to be sent.

I'd, as always, especially like @citrus-it to look at this, as all the real work was done by him.  I'd also appreciate anyone bored giving it some more testing.

The test suite all passes (both python versions), and smoke tests on a running system are fine.

The last 3 commits fix other things that are not necessarily related.  I'm not sure if what I did to the bhyve brand dependencies is correct.
