### PR TITLE
Update release note URL to point to new website

### DIFF
--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -115,12 +115,12 @@ Service Request about this issue including the information above and this
 message.""").format(version=VERSION)
 
 def get_release_notes_url():
-        """Return a release note URL pointing to the correct release notes
-           for this version"""
+        """Return a URL pointing to release notes"""
+        # Note: Would ideally return a release version specific URL
 
         # TBD: replace with a call to api.info() that can return a "release"
         # attribute of form YYYYMM against the SUNWsolnm package
-        return "https://docs.openindiana.org/release-notes/latest-changes/"
+        return "https://www.openindiana.org/"
 
 def time_to_timestamp(t):
         """convert seconds since epoch to %Y%m%dT%H%M%SZ format"""


### PR DESCRIPTION
As noted in [Bug #14854](https://www.illumos.org/issues/14854) and in [oi-docs PR #237](https://github.com/OpenIndiana/oi-docs/pull/237) the URL returned is to an outdated page of the documentation site.

The release notes for OI version can be found in the [announcements section of the main website](https://www.openindiana.org/). I propose changing the link to point to this page instead, as the release notes are part of the announcements. I also propose either removing the release notes from the documentation site, or linking to the relevant page of the main website (not duplicating information).

I've also updated the description to make it clear this method is not version specific. From the existing notes this appeared to be a historical aspiration. This could work with the website if the pages were consistently named, but this seems a comparatively low priority.