### PR TITLE
Add dependency six-39

### DIFF
--- a/src/pkg/manifests/package:pkg.p5m
+++ b/src/pkg/manifests/package:pkg.p5m
@@ -478,5 +478,6 @@ depend type=require fmri=crypto/ca-certificates
 # CFFI import is done in C code, so it isn't picked up by pkgdepend
 depend type=require fmri=library/python/cffi
 depend type=require fmri=library/python/prettytable
+depend type=require fmri=library/python/six-39
 depend type=require fmri=locale/en
 depend type=require fmri=system/library/python/libbe-39


### PR DESCRIPTION
pkg requires six at runtime but the current manifest doesn't reflect that, resulting in:
https://www.illumos.org/issues/16169
https://github.com/OpenIndiana/oi-userland/discussions/14686

It's been suggested that we could remove the dependency on six from the codebase, but at least until such a time the dependencies should be indicated correctly.

This is the correct way to introduce a runtime dependency for this package, yes?  I'm new to the tooling, but it seems to produce the correct result.  (I did run it through pkgfmt.)