### PR TITLE
pkg.7: debug and optional facets are false by default

### DIFF
--- a/src/man/pkg.7
+++ b/src/man/pkg.7
@@ -2,7 +2,7 @@
 .\" Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
 .\" Copyright (c) 2012, OmniTI Computer Consulting, Inc. All rights reserved.
 .\" Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
-.TH pkg 7 "10 Sep 2018" "SunOS 5.11" "Standards, Environments, and Macros"
+.TH pkg 7 "26 Feb 2024" "SunOS 5.11" "Standards, Environments, and Macros"
 .SH NAME
 pkg \- Image Packaging System
 .SH DESCRIPTION
@@ -1507,7 +1507,7 @@ An example of a variant tag is \fBvariant.arch=sparc\fR. An example of a facet t
 Facets and variants are special properties of the image and cannot be set on individual packages. To view the current values of the facets and variants set on the image, use the \fBpkg facet\fR and \fBpkg variant\fR commands as shown in the \fBpkg\fR(1) man page. To modify the values of the facets and variants set on the image, use the \fBpkg change-facet\fR and \fBpkg change-variant\fR commands.
 .sp
 .LP
-Facets are treated as boolean values by package clients: Facets can be set only to \fBtrue\fR (enabled) or \fBfalse\fR (disabled) in the image. By default, all facets are considered to be set to \fBtrue\fR in the image.
+Facets are treated as boolean values by package clients: Facets can be set only to \fBtrue\fR (enabled) or \fBfalse\fR (disabled) in the image. By default, all facets starting with 'facet.debug.' or 'facet.optional.' are considered to be set to \fBfalse\fR in the image; all others are considered to be set to \fBtrue\fR in the image.
 .sp
 .LP
 Facets can be either set locally within an image using the \fBpkg change-facet\fR command or inherited from a parent image. For example, a non-global zone can inherit a facet from the global zone. Inherited facets are evaluated before, and take priority over, any locally set facets. If the same facet is both inherited and locally set, the inherited facet value masks the locally set value. Masked facets have no effect on facet evaluation and package actions. Facet changes made by using the \fBpkg change-facet\fR command only affect locally set facets. Inherited facets can only be changed by making the change in the parent image. By default, the \fBpkg facet\fR command does not display masked facets.
@@ -1599,7 +1599,7 @@ Actions with facet tags are installed if the following conditions exist in the i
 .TP
 .ie t \(bu
 .el o
-All facet tags on the action that have a value of \fBall\fR are \fBtrue\fR in the image (\fBtrue\fR is the default).
+All facet tags on the action that have a value of \fBall\fR are \fBtrue\fR in the image (\fBfalse\fR is the default for all facets starting with 'facet.debug.' or 'facet.optional.'; \fBtrue\fR is the default for all others).
 .RE
 .RS +4
 .TP


### PR DESCRIPTION
This is a backport of [these changes from solaris-ips](https://github.com/oracle/solaris-ips/commit/395ded54d4cc50d69fa1879d56debd43e38ab192#diff-4edac8bc600c7171613baba91a752d7803d355606d7dff2b624aeafad472df11).