### PR TITLE
pkg: fix empty-repo build failure under parallel dmake

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -41,11 +41,11 @@ JOBS = 8
 
 SUBDIRS=brand zoneproxy util/mkcert
 
-all: $(SUBDIRS) build
+all: $(SUBDIRS) .WAIT build
 
 build: $(PYTHON_VERSIONS)
 
-install: $(SUBDIRS) $(PYTHON_VERSIONS)
+install: $(SUBDIRS) .WAIT $(PYTHON_VERSIONS)
 
 clean: $(SUBDIRS) $(PYTHON_VERSIONS)
 	@cd pkg; pwd; make clean

--- a/src/pkg/Makefile
+++ b/src/pkg/Makefile
@@ -60,11 +60,15 @@ PUBLISHALL        = $(POUND_SIGN)
 MANIFESTS.cmd     = \
 	cd manifests; \
 	buildnum=$(BUILDID); \
-	m=$$($(PKGMOGRIFY) -O /dev/null *.p5m ../transforms/nopublish); \
+	if ! m=$$($(PKGMOGRIFY) -O /dev/null *.p5m ../transforms/nopublish); then \
+		echo "ERROR: pkgmogrify failed while computing MANIFESTS." >&2; \
+		echo "       Expected tool at $(PKGROOT)/usr/bin/pkgmogrify" >&2; \
+		echo "       Is the proto area built? Run 'make install' in src/ first." >&2; \
+		exit 1; \
+	fi; \
 	echo "$$m" | while read name build; do \
 		[[ $$build -ge $${buildnum%%.*} ]] && echo $$name; \
-	done | sed -e 's/:/\\:/g'; \
-	exit 0
+	done | sed -e 's/:/\\:/g'
 MANIFESTS         = $(MANIFESTS.cmd:sh)
 ALL_MANIFESTS:sh  = \
 	cd manifests; \

--- a/src/setup.py
+++ b/src/setup.py
@@ -1123,6 +1123,7 @@ class build_py_func(_build_py):
                 # Before building extensions, we need to generate .c files
                 # for the C extension modules by running the CFFI build
                 # script files.
+                cffi_procs = []
                 for path in os.listdir(cffi_dir):
                         if not path.startswith("build_"):
                                 continue
@@ -1135,6 +1136,17 @@ class build_py_func(_build_py):
                         # run the scripts
                         p = subprocess.Popen(
                             [sys.executable, path])
+                        cffi_procs.append((path, p))
+
+                # Wait for the CFFI code generation to finish before returning.
+                # build_ext compiles these generated .c files, so letting the
+                # scripts run in the background races under parallel builds and
+                # can leave C extensions unbuilt.
+                for path, p in cffi_procs:
+                        if p.wait() != 0:
+                                print("ERROR: CFFI build script failed: "
+                                    "{0}".format(path), file=sys.stderr)
+                                sys.exit(1)
 
                 return ret
 


### PR DESCRIPTION
## What
Fixes a build failure where the pkg5 component publishes zero packages and then dies with a misleading `E_HTTP_NOT_FOUND ... does not contain a valid package repository` error.

## Root cause
When the build environment sets DMAKE_MAX_JOBS (the OI Jenkins nightly exports an invalid <=0 value that dmake resets to 2), the src build runs under parallel Sun make. Two latent problems then bite:
1. all:/install: in src/Makefile impose no ordering between the C subdirs and the setup.py build/install.
2. setup.py fires the CFFI codegen scripts via Popen and never waits for them, so build_ext can compile .c files that aren't finished being generated.

Under parallelism this leaves the proto area incompletely populated (e.g. proto/root_$ARCH/usr/bin/pkgmogrify missing). MANIFESTS.cmd in src/pkg/Makefile then shells out to pkgmogrify to compute the manifests to publish, but swallowed any failure with a trailing `exit 0`, so a missing/broken pkgmogrify silently produced an empty MANIFESTS. Nothing was published and the failure only surfaced much later as the confusing "invalid package repository" error. A serial build works fine, which is why this only reproduces in CI.

## Changes
- src/Makefile: add .WAIT between $(SUBDIRS) and the Python build/install so the C subdirs finish first — makes all/install parallel-safe.
- src/setup.py: collect the CFFI codegen subprocesses and wait for them (failing loudly on error) before build_ext compiles the generated .c files.
- src/pkg/Makefile: MANIFESTS.cmd now aborts with a clear diagnostic when pkgmogrify fails instead of silently yielding an empty manifest list. clean/clobber don't reference MANIFESTS, so they still work on a tree with no proto.

## Notes
The CI trigger (bogus DMAKE_MAX_JOBS) is pinned separately in oi-userland by forcing the pkg5 sub-build serial (export DMAKE_MAX_JOBS=1 in .built). The changes here are the root-cause hardening and make any future occurrence fail visibly.